### PR TITLE
feat: Add Shape support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+TODO.md

--- a/src/enums/shape_dim.rs
+++ b/src/enums/shape_dim.rs
@@ -1,0 +1,60 @@
+//! # ShapeDim Enum Module
+//!
+//! Companion to [crate::traits::shape::Shape];
+//!
+//! Contains all supported `Shape` variants.
+
+use crate::traits::shape::Shape;
+
+/// Recursively-describable dimensional rank for any `Value`.
+#[derive(Clone, PartialEq, Eq)]
+pub enum ShapeDim {
+    /// Rank-0 - must always be `1`
+    Rank0(usize),
+
+    /// Array row count
+    Rank1(usize),
+
+    /// Relational table with row/column counts.
+    Rank2 { rows: usize, cols: usize },
+
+    /// 3d object
+    Rank3 { x: usize, y: usize, z: usize },
+
+    /// 4d Object
+    Rank4 {
+        a: usize,
+        b: usize,
+        c: usize,
+        d: usize,
+    },
+
+    /// N-dimensional tensor.
+    RankN(Vec<usize>),
+
+    /// Dictionary shape
+    Dictionary {
+        // Number of keys
+        n_keys: usize,
+        // Number of values for each key
+        n_values: Vec<usize>,
+    },
+
+    /// Heterogeneous ordered collection.
+    /// Covers lists, tuples, cubes (with varying row-counts) and user-custom chunked types.
+    ///
+    /// The order is significant; for tuples it is the fixed arity order.
+    Collection(Vec<ShapeDim>),
+
+    /// Shape could not be determined.
+    Unknown,
+}
+
+
+/// Implement `Shape` for `ShapeDim` so recursive calls like `item.shape_3d()`
+/// compile when iterating `Collection(Vec<ShapeDim>)`.
+impl Shape for ShapeDim {
+    fn shape(&self) -> ShapeDim {
+        self.clone()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub mod enums {
         pub mod temporal_array;
     }
     pub mod operators;
+    pub mod shape_dim;
 }
 
 /// Contains SIMD-accelerated kernels for the 'essentials' that are highly coupled to this crate
@@ -179,6 +180,7 @@ pub mod traits {
     pub mod print;
     pub mod type_unions;
     pub mod custom_value;
+    pub mod shape;
 }
 
 pub mod aliases;

--- a/src/structs/bitmask.rs
+++ b/src/structs/bitmask.rs
@@ -18,6 +18,8 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::{BitAnd, BitOr, Deref, DerefMut, Index, Not};
 
 use crate::structs::vec64::Vec64;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{BitmaskV, Buffer, Length, Offset};
 
 /// TODO: Move bitmask kernels here
@@ -731,6 +733,11 @@ impl Display for Bitmask {
     }
 }
 
+impl Shape for Bitmask {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -13,6 +13,8 @@ use std::iter::FromIterator;
 #[cfg(feature = "views")]
 use std::sync::Arc;
 
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 #[cfg(feature = "views")]
 use crate::ArrayV;
 #[cfg(feature = "views")]
@@ -716,6 +718,12 @@ impl FromIterator<FieldArray> for SuperArray {
 impl From<FieldArray> for SuperArray {
     fn from(field_array: FieldArray) -> Self {
         SuperArray { arrays: vec![field_array] }
+    }
+}
+
+impl Shape for SuperArray {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/chunked/super_table.rs
+++ b/src/structs/chunked/super_table.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use crate::structs::field::Field;
 use crate::structs::field_array::FieldArray;
 use crate::structs::table::Table;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 #[cfg(feature = "views")]
 use crate::{SuperTableV, TableV};
 
@@ -154,6 +156,12 @@ impl SuperTable {
     pub fn n_cols(&self) -> usize {
         self.schema.len()
     }
+
+    #[inline]
+    pub fn n_rows(&self) -> usize {
+        self.n_rows
+    }
+
     #[inline]
     pub fn n_batches(&self) -> usize {
         self.batches.len()
@@ -223,6 +231,7 @@ impl SuperTable {
             name
         }
     }
+
 }
 
 impl Default for SuperTable {
@@ -235,6 +244,12 @@ impl FromIterator<Table> for SuperTable {
     fn from_iter<T: IntoIterator<Item = Table>>(iter: T) -> Self {
         let batches: Vec<Arc<Table>> = iter.into_iter().map(|x| x.into()).collect();
         SuperTable::from_batches(batches, None)
+    }
+}
+
+impl Shape for SuperTable {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank2 { rows: self.n_rows(), cols: self.n_cols() }
     }
 }
 

--- a/src/structs/cube.rs
+++ b/src/structs/cube.rs
@@ -32,6 +32,8 @@ use super::field_array::FieldArray;
 #[cfg(feature = "views")]
 use crate::aliases::CubeV;
 use crate::ffi::arrow_dtype::ArrowType;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Field, Table};
 #[cfg(feature = "views")]
 use crate::TableV;
@@ -64,6 +66,7 @@ pub struct Cube {
     pub tables: Vec<Table>,
     /// Number of rows in each table
     pub n_rows: Vec<usize>,
+    
     /// Cube name
     pub name: String,
     // Third-dimensional index column names
@@ -158,6 +161,11 @@ impl Cube {
     /// Returns the number of tables.
     pub fn n_tables(&self) -> usize {
         self.tables.len()
+    }
+
+    /// Returns the number of rows
+    pub fn n_rows(&self) -> Vec<usize> {
+        self.n_rows.clone()
     }
 
     /// Returns the number of columns.
@@ -438,6 +446,13 @@ impl IntoIterator for Cube {
         self.tables.into_iter()
     }
 }
+
+impl Shape for Cube {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Collection(self.tables.iter().map(|t| t.shape()).collect())
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -21,6 +21,8 @@ use polars::series::Series;
 #[cfg(feature = "views")]
 use crate::aliases::FieldAVT;
 use crate::ffi::arrow_dtype::ArrowType;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Array, Field};
 
 
@@ -242,6 +244,12 @@ impl Display for FieldArray {
             self.field.dtype
         )?;
         self.array.fmt(f)
+    }
+}
+
+impl Shape for FieldArray {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -26,6 +26,8 @@ use polars::prelude::Column;
 use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator};
 
 use super::field_array::FieldArray;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::Field;
 #[cfg(feature = "views")]
 use crate::TableV;
@@ -329,6 +331,12 @@ impl IntoIterator for Table {
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.cols.into_iter()
+    }
+}
+
+impl Shape for Table {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank2 { rows: self.n_rows(), cols: self.n_cols() } 
     }
 }
 

--- a/src/structs/variants/boolean.rs
+++ b/src/structs/variants/boolean.rs
@@ -44,6 +44,8 @@ use crate::aliases::BooleanAVT;
 use crate::structs::bitmask::Bitmask;
 use crate::traits::masked_array::MaskedArray;
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::utils::validate_null_mask_len;
 use crate::{Length, Offset, Vec64, impl_arc_masked_array};
 
@@ -757,6 +759,12 @@ impl<T: Send + Sync> BooleanArray<T> {
             }
             Some(unsafe { self.data.get_unchecked(i) })
         })
+    }
+}
+
+impl Shape for BooleanArray<()> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/variants/categorical.rs
+++ b/src/structs/variants/categorical.rs
@@ -30,6 +30,8 @@ use rayon::iter::ParallelIterator;
 use crate::aliases::CategoricalAVT;
 use crate::structs::allocator::Alloc64;
 use crate::structs::vec64::Vec64;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::traits::type_unions::Integer;
 use crate::utils::validate_null_mask_len;
 use crate::{
@@ -1019,6 +1021,12 @@ impl<T: Integer + Send + Sync> CategoricalArray<T> {
             let idx = unsafe { *idx_buf.get_unchecked(i) }.to_usize();
             Some(unsafe { dict.get_unchecked(idx).as_str() })
         })
+    }
+}
+
+impl<T: Integer> Shape for CategoricalArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/variants/datetime.rs
+++ b/src/structs/variants/datetime.rs
@@ -36,6 +36,8 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 #[cfg(feature = "datetime")]
 use crate::Buffer;
 use crate::enums::time_units::TimeUnit;
@@ -355,6 +357,12 @@ where
         }
 
         write!(f, "]")
+    }
+}
+
+impl<T: Integer> Shape for DatetimeArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/variants/float.rs
+++ b/src/structs/variants/float.rs
@@ -45,6 +45,8 @@ use std::fmt::{Display, Formatter};
 
 use crate::structs::vec64::Vec64;
 use crate::traits::print::{MAX_PREVIEW, format_float};
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::traits::type_unions::Float;
 use crate::{
     Bitmask, Buffer, Length, MaskedArray, Offset, impl_arc_masked_array, impl_array_ref_deref,
@@ -141,6 +143,12 @@ where
         }
 
         write!(f, "]")
+    }
+}
+
+impl<T: Float> Shape for FloatArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/variants/integer.rs
+++ b/src/structs/variants/integer.rs
@@ -42,6 +42,8 @@ use std::fmt::{Display, Formatter};
 
 use crate::structs::vec64::Vec64;
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::traits::type_unions::Integer;
 use crate::{
     Bitmask, Buffer, Length, MaskedArray, Offset, impl_arc_masked_array, impl_array_ref_deref,
@@ -136,6 +138,12 @@ where
         }
 
         write!(f, "]")
+    }
+}
+
+impl<T: Integer> Shape for IntegerArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/variants/string.rs
+++ b/src/structs/variants/string.rs
@@ -39,6 +39,8 @@ use rayon::iter::ParallelIterator;
 use crate::structs::vec64::Vec64;
 use crate::traits::masked_array::MaskedArray;
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::traits::type_unions::Integer;
 use crate::utils::validate_null_mask_len;
 use crate::{
@@ -1281,6 +1283,12 @@ impl_arc_masked_array!(
     Variant = TextArray,
     Bound = Integer,
 );
+
+impl<T: Integer> Shape for StringArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
+    }
+}
 
 impl<T: Zero> Default for StringArray<T> {
     fn default() -> Self {

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -31,6 +31,8 @@ use std::cell::Cell;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Array, BitmaskV, FieldArray, MaskedArray, TextArray};
 
 /// # ArrayView
@@ -345,6 +347,11 @@ impl Display for ArrayV {
     }
 }
 
+impl Shape for ArrayV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/structs/views/bitmask_view.rs
+++ b/src/structs/views/bitmask_view.rs
@@ -30,6 +30,8 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Bitmask, BitmaskVT};
 
 /// # BitmaskView
@@ -239,6 +241,12 @@ impl Display for BitmaskV {
         writeln!(f)?;
 
         Ok(())
+    }
+}
+
+impl Shape for BitmaskV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/views/chunked/super_array_view.rs
+++ b/src/structs/views/chunked/super_array_view.rs
@@ -33,7 +33,7 @@
 //! - `field` is the schema for the underlying array and is shared by all slices.
 use std::sync::Arc;
 
-use crate::{Array, ArrayV, ArrayVT, Field, SuperArray};
+use crate::{enums::shape_dim::ShapeDim, traits::shape::Shape, Array, ArrayV, ArrayVT, Field, SuperArray};
 
 /// # SuperArrayView
 /// 
@@ -67,6 +67,7 @@ impl SuperArrayV {
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+    
     #[inline]
     pub fn n_slices(&self) -> usize {
         self.slices.len()
@@ -166,6 +167,17 @@ impl SuperArrayV {
         let (ci, ri) = self.locate(row);
         let (array, base_offset, _) = self.slices[ci].as_tuple();
         ArrayV::new(array, base_offset + ri, 1)
+    }
+
+    /// Returns the total number of elements in the array
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl Shape for SuperArrayV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/views/chunked/super_table_view.rs
+++ b/src/structs/views/chunked/super_table_view.rs
@@ -33,6 +33,8 @@
 //!   within its underlying table batch.
 
 use crate::structs::chunked::super_table::SuperTable;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Table, TableV};
 
 /// # SuperTableView
@@ -139,6 +141,32 @@ impl SuperTableV {
     pub fn row_slice(&self, row: usize) -> TableV {
         let (ci, ri) = self.locate(row);
         self.slices[ci].from_self(ri, 1)
+    }
+ 
+    /// Returns the total number of rows in the Super table across all chunks
+    #[inline]
+    pub fn n_rows(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the number of columns in the Super table.
+    /// 
+    /// Assumes that every chunk has the same column schema as per
+    /// the semantic requirement.
+    #[inline]
+    pub fn n_cols(&self) -> usize {
+        let n_batches = self.slices.len();
+        if n_batches > 0 {
+           self.slices[0].fields.len()
+        } else {
+            0
+        }
+    }
+}
+
+impl Shape for SuperTableV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank2 { rows: self.n_rows(), cols: self.n_cols() }
     }
 }
 

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -34,6 +34,8 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::structs::views::bitmask_view::BitmaskV;
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Array, ArrayV, FieldArray, MaskedArray, NumericArray};
 
 /// # NumericArrayView
@@ -342,6 +344,12 @@ impl Display for NumericArrayV {
         }
 
         Ok(())
+    }
+}
+
+impl Shape for NumericArrayV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/views/collections/temporal_array_view.rs
+++ b/src/structs/views/collections/temporal_array_view.rs
@@ -32,6 +32,8 @@ use std::cell::Cell;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Array, ArrayV, BitmaskV, MaskedArray, TemporalArray};
 
 /// # TemporalArrayView
@@ -365,6 +367,12 @@ impl Display for TemporalArrayV {
         }
 
         Ok(())
+    }
+}
+
+impl Shape for TemporalArrayV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/views/collections/text_array_view.rs
+++ b/src/structs/views/collections/text_array_view.rs
@@ -29,6 +29,8 @@ use std::cell::Cell;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 use crate::{Array, ArrayV, BitmaskV, TextArray};
 
 /// # TextArrayView
@@ -284,6 +286,12 @@ impl Display for TextArrayV {
         }
 
         Ok(())
+    }
+}
+
+impl Shape for TextArrayV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
     }
 }
 

--- a/src/structs/views/table_view.rs
+++ b/src/structs/views/table_view.rs
@@ -45,6 +45,8 @@
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use crate::traits::shape::Shape;
+use crate::enums::shape_dim::ShapeDim;
 #[cfg(feature = "views")]
 use crate::ArrayV;
 use crate::traits::print::MAX_PREVIEW;
@@ -304,6 +306,12 @@ impl Display for TableV {
         }
 
         Ok(())
+    }
+}
+
+impl Shape for TableV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank2 { rows: self.n_rows(), cols: self.n_cols() } 
     }
 }
 

--- a/src/traits/shape.rs
+++ b/src/traits/shape.rs
@@ -1,0 +1,176 @@
+//! # Shape Trait Module
+//!
+//! Unified way to describe the dimensionality “shape” of any `Value`.  
+//!
+//! Shapes recursively support scalars, arrays, tables,
+//! tuples, chunked data, and arbitrary nested collections,
+//! but include standard accessors for 1d, 2d, etc. to avoid penalising you.
+
+use crate::enums::shape_dim::ShapeDim;
+
+/// Shape trait.
+///
+/// Returns a recursively-describable `Shape` for the receiver.
+/// 
+/// Includes accessor types for common use cases e.g., shape_1d, shape_2d,
+/// which are automatic provided the implementor implements `shape`.
+pub trait Shape {
+
+    /// Returns arbitrary Shape dimension for any data shape
+    fn shape(&self) -> ShapeDim;
+
+    /// Returns the first dimension shape
+    /// 
+    /// Exists to bypass a match on `ShapeDim` for `Array` shaped types
+    fn shape_1d(&self) -> usize {
+        match self.shape() {
+            ShapeDim::Rank0(n) => n,
+            ShapeDim::Rank1(n) => n,
+            ShapeDim::Rank2 { rows, .. } => rows,
+            ShapeDim::Rank3 { x, .. } => x,
+            ShapeDim::Rank4 { a, .. } => a,
+            ShapeDim::RankN(dims) => *dims.get(0).unwrap_or(&1),
+            ShapeDim::Collection(items) => items.iter().map(|x| x.shape_1d()).sum(),
+            ShapeDim::Dictionary { .. } => panic!("shape_1d: incompatible Dictionary shape"),
+            ShapeDim::Unknown => panic!("shape_1d: incompatible Unknown shape"),
+        }
+    }
+
+    /// Returns the first and second dimension shapes
+    /// 
+    /// Exists to bypass a match on `ShapeDim` for `Table` shaped types
+    fn shape_2d(&self) -> (usize, usize) {
+        match self.shape() {
+            ShapeDim::Rank0(n) => (n, 1),
+            ShapeDim::Rank1(n) => (n, 1),
+            ShapeDim::Rank2 { rows, cols } => (rows, cols),
+            ShapeDim::Rank3 { x, y, .. } => (x, y),
+            ShapeDim::Rank4 { a, b, .. } => (a, b),
+            ShapeDim::RankN(dims) => (*dims.get(0).unwrap_or(&1), *dims.get(1).unwrap_or(&1)),
+            ShapeDim::Collection(items) => {
+                let mut total_rows = 0usize;
+                let mut ref_cols: Option<usize> = None;
+
+                for item in items {
+                    let (rows, cols) = item.shape_2d();
+                    total_rows += rows;
+
+                    match ref_cols {
+                        None => ref_cols = Some(cols),
+                        Some(prev) if prev == cols => {}
+                        Some(prev) => panic!(
+                            "shape_2d: column mismatch in Collection: {} vs {}",
+                            prev, cols
+                        ),
+                    }
+                }
+
+                (total_rows, ref_cols.unwrap_or(1))
+            }
+            ShapeDim::Dictionary { .. } => panic!("shape_2d: incompatible Dictionary shape"),
+            ShapeDim::Unknown => panic!("shape_2d: incompatible Unknown shape"),
+        }
+    }
+
+    /// Returns the first, second and third dimension shapes
+    /// 
+    /// Exists to bypass a match on `ShapeDim` for 3D types
+    fn shape_3d(&self) -> (usize, usize, usize) {
+        match self.shape() {
+            ShapeDim::Rank0(n) => (n, 1, 1),
+            ShapeDim::Rank1(n) => (n, 1, 1),
+            ShapeDim::Rank2 { rows, cols } => (rows, cols, 1),
+            ShapeDim::Rank3 { x, y, z } => (x, y, z),
+            ShapeDim::Rank4 { a, b, c, .. } => (a, b, c),
+            ShapeDim::RankN(dims) => (
+                *dims.get(0).unwrap_or(&1),
+                *dims.get(1).unwrap_or(&1),
+                *dims.get(2).unwrap_or(&1),
+            ),
+            ShapeDim::Collection(items) => {
+                let mut total_a = 0usize;
+                let mut ref_b: Option<usize> = None;
+                let mut ref_c: Option<usize> = None;
+
+                for item in items {
+                    let (a, b, c) = item.shape_3d();
+                    total_a += a;
+
+                    match ref_b {
+                        None => ref_b = Some(b),
+                        Some(prev) if prev == b => {}
+                        Some(prev) => panic!(
+                            "shape_3d: 2nd dim mismatch in Collection: {} vs {}",
+                            prev, b
+                        ),
+                    }
+
+                    match ref_c {
+                        None => ref_c = Some(c),
+                        Some(prev) if prev == c => {}
+                        Some(prev) => panic!(
+                            "shape_3d: 3rd dim mismatch in Collection: {} vs {}",
+                            prev, c
+                        ),
+                    }
+                }
+
+                (total_a, ref_b.unwrap_or(1), ref_c.unwrap_or(1))
+            }
+            ShapeDim::Dictionary { .. } => panic!("shape_3d: incompatible Dictionary shape"),
+            ShapeDim::Unknown => panic!("shape_3d: incompatible Unknown shape"),
+        }
+    }
+
+    /// Returns the first, second, third and fourth dimension shapes
+    /// 
+    /// Exists to bypass a match on `ShapeDim` for 4D types
+    fn shape_4d(&self) -> (usize, usize, usize, usize) {
+        match self.shape() {
+            ShapeDim::Rank0(n) => (n, 1, 1, 1),
+            ShapeDim::Rank1(n) => (n, 1, 1, 1),
+            ShapeDim::Rank2 { rows, cols } => (rows, cols, 1, 1),
+            ShapeDim::Rank3 { x, y, z } => (x, y, z, 1),
+            ShapeDim::Rank4 { a, b, c, d } => (a, b, c, d),
+            ShapeDim::RankN(dims) => (
+                *dims.get(0).unwrap_or(&1),
+                *dims.get(1).unwrap_or(&1),
+                *dims.get(2).unwrap_or(&1),
+                *dims.get(3).unwrap_or(&1),
+            ),
+            ShapeDim::Collection(items) => {
+                let mut total_a = 0usize;
+                let mut ref_b: Option<usize> = None;
+                let mut ref_c: Option<usize> = None;
+                let mut ref_d: Option<usize> = None;
+
+                for item in items {
+                    let (a, b, c, d) = item.shape_4d();
+                    total_a += a;
+
+                    match ref_b {
+                        None => ref_b = Some(b),
+                        Some(prev) if prev == b => {}
+                        Some(prev) => panic!("shape_4d: 2nd dim mismatch: {} vs {}", prev, b),
+                    }
+
+                    match ref_c {
+                        None => ref_c = Some(c),
+                        Some(prev) if prev == c => {}
+                        Some(prev) => panic!("shape_4d: 3rd dim mismatch: {} vs {}", prev, c),
+                    }
+
+                    match ref_d {
+                        None => ref_d = Some(d),
+                        Some(prev) if prev == d => {}
+                        Some(prev) => panic!("shape_4d: 4th dim mismatch: {} vs {}", prev, d),
+                    }
+                }
+
+                (total_a, ref_b.unwrap_or(1), ref_c.unwrap_or(1), ref_d.unwrap_or(1))
+            }
+            ShapeDim::Dictionary { .. } => panic!("shape_4d: incompatible Dictionary shape"),
+            ShapeDim::Unknown => panic!("shape_4d: incompatible Unknown shape"),
+        }
+    }
+}


### PR DESCRIPTION
Added dimensional shape support for all container types.

Adds `.shape()` usage for arbitrary nested types, but retains 1D, 2D, 3D, 4D accessors to avoid penalties.