### PR TITLE
Minarrow Release: v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,10 +480,8 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -494,7 +492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -678,6 +676,15 @@ name = "debug_unsafe"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85d3cef41d236720ed453e102153a53e4cc3d2fde848c0078a50cf249e8e3e5b"
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1498,21 +1505,22 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-schema",
  "cc",
- "chrono",
  "memchr",
  "num-traits",
+ "phf 0.11.3",
  "polars",
  "polars-arrow",
  "rayon",
  "regex",
  "ryu",
  "snappy",
+ "time",
  "vec64",
  "zstd",
 ]
@@ -1580,6 +1588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,7 +1672,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "serde",
@@ -1719,11 +1742,53 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1843,7 +1908,7 @@ dependencies = [
  "polars-arrow",
  "polars-error",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "ryu",
  "serde",
  "skiplist",
@@ -1876,7 +1941,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
  "regex",
@@ -1935,7 +2000,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "recursive",
 ]
@@ -2190,7 +2255,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde",
  "sqlparser",
@@ -2225,7 +2290,7 @@ dependencies = [
  "polars-parquet",
  "polars-plan",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "recursive",
  "slotmap",
@@ -2274,7 +2339,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "polars-error",
- "rand",
+ "rand 0.9.2",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2296,6 +2361,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2363,7 +2434,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2406,12 +2477,21 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2421,8 +2501,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2440,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2897,7 +2983,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f354fd282d3177c2951004953e2fdc4cb342fa159bbee8b829852b6a081c8ea1"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "thiserror",
 ]
 
@@ -3085,6 +3171,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minarrow"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ['Peter G. Bower']
 build = "build.rs"
@@ -41,7 +41,8 @@ polars = { version = "0.50.0", features = [
     "fmt",
 ], optional = true }
 polars-arrow = { version = "0.50.0", optional = true }
-chrono = { version = "0.4.41", optional = true }
+time = { version = "0.3", optional = true, features = ["parsing", "formatting", "macros", "local-offset"] }
+phf = { version = "0.11", features = ["macros"], optional = true }
 num-traits = "0.2.19"
 rayon = { version = "1.10.0", optional = true }
 snappy = { version = "0.4.0", optional = true }
@@ -146,13 +147,18 @@ datetime = []
 # A much more extensive set of kernels is available under the downstream simd-kernels crate.
 simd = []
 
-# Adds `as_datetime` outputs for easy conversion.
-# Also, formats datetime values as dates since unix epoch 1970-01-01 .
-# Without this, they are raw values that can either represent
-# since epoch, or just be a standalone length, depending on your
-# requirements, and the `ArrowType` you can store in `Field` and/or `FieldArray`
-# tags this accurately for each use case, along with any optional metadata.
-chrono = ["dep:chrono", "datetime"]
+# Adds full datetime functionality with the `time` crate including:
+# - Human-readable datetime conversions
+# - Timezone-aware operations
+# - Date/time arithmetic (add/subtract durations, dates)
+# - Comparison operations
+# - Component extraction (year, month, day, hour, etc.)
+# At, the expense of an external dependency.
+#
+# Without this feature, datetime values are raw integer offsets.
+# The `ArrowType` stored in `Field` and/or `FieldArray` specifies the
+# logical type (Date32, Date64, Timestamp, etc.) for Arrow FFI compatibility.
+datetime_ops = ["dep:time", "dep:phf", "datetime"]
 
 # Adds string arithmetic kernels
 # Includes (small) external dependencies, and supports

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Minarrow - *Apache Arrow tuned for HPC, Native Streaming, and Embedded*
+# Minarrow - *Apache Arrow tuned for HPC, Live, and Embedded*
 
 ## Intro
 
 Minarrow is a from-scratch columnar library built for real-time and systems workloads in Rust.
-It keeps the surface small, makes types explicit, compiles fast, and aligns data for predictable SIMD performance.
-It speaks Arrow when you need to talk interchange — but the core stays lean.
+It keeps the surface small, gives you IDE types, compiles fast, and aligns data for fast SIMD performance.
+It speaks Arrow when you need to talk interchange — but the core stays lean and mean.
 
-Minarrow is the base layer of several related projects that expand on it to deliver a full set of SIMD-accelerated Kernels, Tokio streamable buffers, and a full-scale engine.
+Minarrow is the base layer of several epic projects that expand on it to deliver a full set of SIMD-accelerated Kernels, Tokio streamable buffers, and a full-scale engine.
 
 ## Design Focus
 
-- **Typed, direct access** – No downcasting chains
+- **Typed, direct access** – No downcasting horror.
 - **High performance** – 64-byte SIMD-compatible alignment by default
 - **Fast iteration** – Minimal dependencies, sub-1.5 s clean builds, <0.15 s rebuilds
 - **Interoperability on demand** – Convert to and from Arrow at the boundary
@@ -19,7 +19,7 @@ Minarrow is the base layer of several related projects that expand on it to deli
 
 - The **Arrow** format is a powerful standard for columnar data. ***Apache Arrow*** has driven an entire ecosystem forward, with zero-copy interchange, multi-language support, and extensive integration.
 - ***Minarrow*** complements that ecosystem by focusing on Rust-first ergonomics, predictable SIMD behaviour, and extremely low build-time friction.
-- It's **easy, fast, and simple** — built to deliver extreme performance without sacrificing ergonomics.
+- **Easy, fast, and simple** — delivers extreme performance without sacrificing ergonomics.
 
 ## Key Features
 
@@ -29,7 +29,9 @@ Minarrow compiles in under 1.5 seconds with default features, minimising develop
 
 ### Data access
 
-Minarrow provides direct, always-typed access to array values. Unlike other Rust implementations that unify all array types as untyped byte buffers *(requiring downcasting and dynamic checks)*, Minarrow retains concrete types throughout the API. This enables developers to inspect and manipulate data without downcasting or additional indirection, ensuring safe and ergonomic access at all times.
+Minarrow provides direct, typed access to array values. Unlike other Rust implementations that unify all array types as untyped byte buffers *(requiring downcasting and dynamic checks)*, Minarrow retains concrete types throughout the API. This enables developers to inspect and manipulate data without downcasting or additional indirection, retaining safe and ergonomic access at all times.
+
+**Outcome**: *You get a data library feel instead of an opaque systems-programming interface in Rust. Though, these data building blocks are capable of powering some of the most demanding and high-performance apps.*
 
 ## Type System
 
@@ -77,8 +79,8 @@ let array = Array::NumericArray(wrapped);
 ```rust
 use minarrow::{FieldArray, Print, Table, arr_i32, arr_str32, vec64};
 
-let col1 = FieldArray::from_inner("numbers", arr_i32![1, 2, 3]);
-let col2 = FieldArray::from_inner("letters", arr_str32!["x", "y", "z"]);
+let col1 = FieldArray::from_arr("numbers", arr_i32![1, 2, 3]);
+let col2 = FieldArray::from_arr("letters", arr_str32!["x", "y", "z"]);
 
 let mut tbl = Table::new("Demo".into(), vec![col1, col2].into());
 tbl.print();
@@ -88,6 +90,10 @@ See _examples/_ for more.
 
 When working with arrays, remember to import the `MaskedArray` trait,
 which ensures all required methods are available.
+
+## Broadcasting
+Broadcasting is built-in via the `broadcasting` feature. You can add, subtract, divide or multiply all `Value` types,
+including tuples.
 
 ## SIMD by Default
 
@@ -116,15 +122,19 @@ The structure is layered:
 This design supports flexible function signatures like `impl Into<NumericArray>` while preserving static typing.
 Because dispatch is static, the compiler retains full knowledge of types across calls, enabling inlining and eliminating virtual call overhead.
 
-### Flexible Integration
+### Flexible
 - **Apache Arrow** compatibility via `.to_apache_arrow()`.
 - **Polars** compatibility via `.to_polars()`.
+- **Datetime support** – Minarrow supports optionally beefing up Datetimes via the *time* crate, for compatible dt-aware time and ops support.
 - **Async support** through the companion Lightstream crate
 - **Zero-copy** views for windowed operations *(see Views and Windowing below)*
 - **Memory-mapped** file support with maintained SIMD alignment
 - **FFI Support** for cross-language compatibility.
 
-Lightstream *(planned Aug ’25)* enables IPC streaming in Tokio async contexts with composable encoder/decoder traits, both sync and async, without losing SIMD alignment.
+## Partner Crates:
+- `lightstream` enables IPC streaming in Tokio async contexts with composable encoder/decoder traits, both sync and async, without losing SIMD alignment.
+- `simd-kernels` a very large set of simd-kernels **including 60+ distributions (poisson etc.)** ***reconciled to Scipy***. 
+- `vec64` Vec wrapper with a custom 64-byte allocator that enforces optimal SIMD pointer-alignment. 
 
 ## Views and Windowing
 
@@ -207,9 +217,9 @@ _The construction delta is not included in the benchmark timings above._
 
 ## Design Philosophy
 
-- **Direct data access** over abstraction layers
-- **Developer velocity** through simple, predictable APIs
-- **Performance** with SIMD as a first-class citizen
+- **Direct access** over abstraction layers
+- **Developer velocity** through simple APIs
+- **Performance** SIMD as a first-class citizen
 - **Interoperability** while maintaining its own identity
 
 This approach trades some features (like deeply nested types) for a more streamlined experience in common data processing scenarios.
@@ -223,10 +233,7 @@ We welcome contributions! Areas of focus include:
 3. **Bug Fixes** - Bug fixes and improvements
 4. **PyO3 Integration** - Python bindings and interoperability
 5. **List and Struct Types** - Support for nested types (PRs welcome)
-6. **Datetime** - Improving datetime ergonomics.
 
-Additionally, if you are interested in working on a SIMD kernels crate that's in development,
-and have relevant experience, please feel free to reach out.
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for contributing guidelines.
 

--- a/examples/broadcasting/test_broadcasting.rs
+++ b/examples/broadcasting/test_broadcasting.rs
@@ -287,8 +287,8 @@ fn test_table_broadcasting() {
     // Create first table with two columns
     let arr1_col1 = Array::from_int32(IntegerArray::from_slice(&vec64![1, 2, 3]));
     let arr1_col2 = Array::from_int32(IntegerArray::from_slice(&vec64![4, 5, 6]));
-    let fa1_col1 = minarrow::FieldArray::from_inner("col1", arr1_col1);
-    let fa1_col2 = minarrow::FieldArray::from_inner("col2", arr1_col2);
+    let fa1_col1 = minarrow::FieldArray::from_arr("col1", arr1_col1);
+    let fa1_col2 = minarrow::FieldArray::from_arr("col2", arr1_col2);
     let mut table1 = Table::new("table1".to_string(), None);
     table1.add_col(fa1_col1);
     table1.add_col(fa1_col2);
@@ -296,8 +296,8 @@ fn test_table_broadcasting() {
     // Create second table with matching structure
     let arr2_col1 = Array::from_int32(IntegerArray::from_slice(&vec64![10, 10, 10]));
     let arr2_col2 = Array::from_int32(IntegerArray::from_slice(&vec64![20, 20, 20]));
-    let fa2_col1 = minarrow::FieldArray::from_inner("col1", arr2_col1);
-    let fa2_col2 = minarrow::FieldArray::from_inner("col2", arr2_col2);
+    let fa2_col1 = minarrow::FieldArray::from_arr("col1", arr2_col1);
+    let fa2_col2 = minarrow::FieldArray::from_arr("col2", arr2_col2);
     let mut table2 = Table::new("table2".to_string(), None);
     table2.add_col(fa2_col1);
     table2.add_col(fa2_col2);
@@ -364,14 +364,14 @@ fn test_super_array_broadcasting() {
         // Create chunked arrays (multiple field array chunks)
         let chunk1_a = Array::from_int32(IntegerArray::from_slice(&vec64![1, 2]));
         let chunk2_a = Array::from_int32(IntegerArray::from_slice(&vec64![3, 4]));
-        let fa1 = minarrow::FieldArray::from_inner("chunk1", chunk1_a);
-        let fa2 = minarrow::FieldArray::from_inner("chunk1", chunk2_a);
+        let fa1 = minarrow::FieldArray::from_arr("chunk1", chunk1_a);
+        let fa2 = minarrow::FieldArray::from_arr("chunk1", chunk2_a);
         let super_arr1 = SuperArray::from_field_array_chunks(vec![fa1, fa2]);
 
         let chunk1_b = Array::from_int32(IntegerArray::from_slice(&vec64![2, 2]));
         let chunk2_b = Array::from_int32(IntegerArray::from_slice(&vec64![2, 2]));
-        let fa3 = minarrow::FieldArray::from_inner("chunk1", chunk1_b);
-        let fa4 = minarrow::FieldArray::from_inner("chunk1", chunk2_b);
+        let fa3 = minarrow::FieldArray::from_arr("chunk1", chunk1_b);
+        let fa4 = minarrow::FieldArray::from_arr("chunk1", chunk2_b);
         let super_arr2 = SuperArray::from_field_array_chunks(vec![fa3, fa4]);
 
         match Value::SuperArray(Arc::new(super_arr1)) * Value::SuperArray(Arc::new(super_arr2)) {
@@ -410,8 +410,8 @@ fn test_cube_broadcasting() {
         // First, create columns for table 1
         let t1_arr1 = Array::from_int32(IntegerArray::from_slice(&vec64![1, 2]));
         let t1_arr2 = Array::from_int32(IntegerArray::from_slice(&vec64![3, 4]));
-        let t1_fa1 = minarrow::FieldArray::from_inner("col1", t1_arr1);
-        let t1_fa2 = minarrow::FieldArray::from_inner("col2", t1_arr2);
+        let t1_fa1 = minarrow::FieldArray::from_arr("col1", t1_arr1);
+        let t1_fa2 = minarrow::FieldArray::from_arr("col2", t1_arr2);
 
         // Create columns for cube1 via constructor
         let mut cube1 = Cube::new("cube1".to_string(), Some(vec![t1_fa1, t1_fa2]), None);
@@ -419,8 +419,8 @@ fn test_cube_broadcasting() {
         // Add second table to cube1
         let t2_arr1 = Array::from_int32(IntegerArray::from_slice(&vec64![5, 6]));
         let t2_arr2 = Array::from_int32(IntegerArray::from_slice(&vec64![7, 8]));
-        let t2_fa1 = minarrow::FieldArray::from_inner("col1", t2_arr1);
-        let t2_fa2 = minarrow::FieldArray::from_inner("col2", t2_arr2);
+        let t2_fa1 = minarrow::FieldArray::from_arr("col1", t2_arr1);
+        let t2_fa2 = minarrow::FieldArray::from_arr("col2", t2_arr2);
         let mut table2 = Table::new("t2".to_string(), None);
         table2.add_col(t2_fa1);
         table2.add_col(t2_fa2);
@@ -429,14 +429,14 @@ fn test_cube_broadcasting() {
         // Create second cube
         let t3_arr1 = Array::from_int32(IntegerArray::from_slice(&vec64![10, 10]));
         let t3_arr2 = Array::from_int32(IntegerArray::from_slice(&vec64![20, 20]));
-        let t3_fa1 = minarrow::FieldArray::from_inner("col1", t3_arr1);
-        let t3_fa2 = minarrow::FieldArray::from_inner("col2", t3_arr2);
+        let t3_fa1 = minarrow::FieldArray::from_arr("col1", t3_arr1);
+        let t3_fa2 = minarrow::FieldArray::from_arr("col2", t3_arr2);
         let mut cube2 = Cube::new("cube2".to_string(), Some(vec![t3_fa1, t3_fa2]), None);
 
         let t4_arr1 = Array::from_int32(IntegerArray::from_slice(&vec64![30, 30]));
         let t4_arr2 = Array::from_int32(IntegerArray::from_slice(&vec64![40, 40]));
-        let t4_fa1 = minarrow::FieldArray::from_inner("col1", t4_arr1);
-        let t4_fa2 = minarrow::FieldArray::from_inner("col2", t4_arr2);
+        let t4_fa1 = minarrow::FieldArray::from_arr("col1", t4_arr1);
+        let t4_fa2 = minarrow::FieldArray::from_arr("col2", t4_arr2);
         let mut table4 = Table::new("t4".to_string(), None);
         table4.add_col(t4_fa1);
         table4.add_col(t4_fa2);

--- a/examples/datetime_ops.rs
+++ b/examples/datetime_ops.rs
@@ -1,0 +1,385 @@
+//! Example of datetime operations with the `time` crate.
+//!
+//! Demonstrates arithmetic, duration calculations, component extraction,
+//! comparisons, truncation, and type casting operations on datetime arrays.
+//!
+//! Run with:
+//!     cargo run --example datetime_operations --features datetime_ops
+
+#[cfg(feature = "datetime_ops")]
+fn main() {
+    use minarrow::{DatetimeArray, FieldArray, MaskedArray, Print, TimeUnit};
+    use minarrow::ffi::arrow_dtype::ArrowType;
+    use time::Duration;
+
+    println!("  Minarrow Datetime Operations Example");
+
+    // Create datetime array with timestamps
+    // - seconds since Unix epoch
+    let timestamps = vec![
+        1_700_000_000, // 2023-11-14 22:13:20 UTC
+        1_700_086_400, // 2023-11-15 22:13:20 UTC
+        1_700_172_800, // 2023-11-16 22:13:20 UTC
+    ];
+    let arr = DatetimeArray::<i64>::from_slice(&timestamps, Some(TimeUnit::Seconds));
+
+    println!("Original datetime array:");
+    for i in 0..arr.len() {
+        if let Some(dt) = arr.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    // Arithmetic Operations
+    println!("\n--- Arithmetic Operations ---");
+
+    let plus_one_hour = arr.add_duration(Duration::hours(1)).unwrap();
+    println!("\nAfter adding 1 hour:");
+    for i in 0..plus_one_hour.len() {
+        if let Some(dt) = plus_one_hour.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    let plus_7_days = arr.add_days(7).unwrap();
+    println!("\nAfter adding 7 days:");
+    for i in 0..plus_7_days.len() {
+        if let Some(dt) = plus_7_days.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    let plus_2_months = arr.add_months(2).unwrap();
+    println!("\nAfter adding 2 months:");
+    for i in 0..plus_2_months.len() {
+        if let Some(dt) = plus_2_months.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    // Duration/Diff Operations
+    println!("\n--- Duration Operations ---");
+
+    // Create array with some times before and some after arr
+    let arr2 = DatetimeArray::<i64>::from_slice(
+        &[
+            1_699_999_000, // 1000 seconds BEFORE arr[0]
+            1_700_086_400, // Same as arr[1]
+            1_700_173_900, // 100 seconds AFTER arr[2]
+        ],
+        Some(TimeUnit::Seconds),
+    );
+
+    // diff() returns signed difference i.e. arr2 - arr
+    let diff_seconds = arr2.diff(&arr, TimeUnit::Seconds).unwrap();
+    println!("\nSigned difference (arr2 - arr) in seconds:");
+    for i in 0..diff_seconds.len() {
+        if let Some(val) = diff_seconds.get(i) {
+            println!("  [{}] {} seconds", i, val);
+        }
+    }
+
+    // abs_diff() returns absolute (unsigned) difference
+    let abs_diff = arr2.abs_diff(&arr, TimeUnit::Seconds).unwrap();
+    println!("\nAbsolute difference in seconds:");
+    for i in 0..abs_diff.len() {
+        if let Some(val) = abs_diff.get(i) {
+            println!("  [{}] {} seconds", i, val);
+        }
+    }
+
+    // Component Extraction
+    println!("\n--- Component Extraction ---");
+
+    // Create a high-precision datetime array to show all granularities
+    // 2023-11-14 22:13:20.123456789 UTC
+    let precise_dt =
+        DatetimeArray::<i64>::from_slice(&[1_700_000_000_123_456_789], Some(TimeUnit::Nanoseconds));
+
+    let years = precise_dt.year();
+    let months = precise_dt.month();
+    let days = precise_dt.day();
+    let hours = precise_dt.hour();
+    let minutes = precise_dt.minute();
+    let seconds = precise_dt.second();
+    let weekdays = precise_dt.weekday();
+    let quarters = precise_dt.quarter();
+    let iso_weeks = precise_dt.iso_week();
+
+    println!("\nExtracted components from datetime:");
+    if let Some(dt) = precise_dt.as_datetime(0) {
+        println!("  Full datetime: {}", dt);
+    }
+    println!("  Year:         {}", years.get(0).unwrap());
+    println!("  Month:        {}", months.get(0).unwrap());
+    println!("  Day:          {}", days.get(0).unwrap());
+    println!("  Hour:         {}", hours.get(0).unwrap());
+    println!("  Minute:       {}", minutes.get(0).unwrap());
+    println!("  Second:       {}", seconds.get(0).unwrap());
+
+    // Show sub-second components by converting to different time units
+    if let Ok(as_millis) = precise_dt.cast_time_unit(TimeUnit::Milliseconds) {
+        let millis_remainder = as_millis.data[0] % 1000;
+        println!("  Millisecond:  {}", millis_remainder);
+    }
+    if let Ok(as_micros) = precise_dt.cast_time_unit(TimeUnit::Microseconds) {
+        let micros_remainder = as_micros.data[0] % 1_000_000;
+        println!("  Microsecond:  {}", micros_remainder % 1000);
+    }
+    let nanos_remainder = precise_dt.data[0] % 1_000_000_000;
+    println!("  Nanosecond:   {}", nanos_remainder % 1000);
+
+    println!(
+        "  Weekday:      {} (1=Sunday, 2=Monday, ..., 7=Saturday)",
+        weekdays.get(0).unwrap()
+    );
+    println!("  Quarter:      {}", quarters.get(0).unwrap());
+    println!("  ISO Week:     {}", iso_weeks.get(0).unwrap());
+
+    let leap_years = precise_dt.is_leap_year();
+    println!("  Leap year?:   {}", leap_years.get(0).unwrap());
+
+    // Comparison Operations
+    println!("\n--- Comparison Operations ---");
+
+    let is_before = arr.is_before(&arr2).unwrap();
+    println!("\narr is_before arr2:");
+    for i in 0..is_before.len() {
+        if let Some(val) = is_before.get(i) {
+            println!("  [{}] {}", i, val);
+        }
+    }
+
+    let is_after = arr.is_after(&arr2).unwrap();
+    println!("\narr is_after arr2:");
+    for i in 0..is_after.len() {
+        if let Some(val) = is_after.get(i) {
+            println!("  [{}] {}", i, val);
+        }
+    }
+
+    // Truncation Operations
+    println!("\n--- Truncation Operations ---");
+
+    let truncated_day = arr.truncate("day").unwrap();
+    println!("\nTruncated to start of day:");
+    for i in 0..truncated_day.len() {
+        if let Some(dt) = truncated_day.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    let truncated_month = arr.truncate("month").unwrap();
+    println!("\nTruncated to start of month:");
+    for i in 0..truncated_month.len() {
+        if let Some(dt) = truncated_month.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+
+    // FieldArray with Timezone Metadata 
+    println!("\n--- FieldArray with Timezone Metadata ---");
+    println!("\nFieldArray allows timezone to be encoded in the ArrowType metadata,");
+    println!("creating a self-describing datetime column with permanent timezone info.");
+    println!("This is the standard pattern Tables with tz-aware columns leverage.");
+    println!("After these examples, we will look at inline Tz cases.");
+
+
+    // Example 1: Single FieldArray with timezone
+    println!("\n1. FieldArray with Sydney timezone:");
+    let sydney_events = DatetimeArray::<i64>::from_slice(
+        &[
+            1_700_000_000, // 2023-11-14 22:13:20 UTC = 2023-11-15 09:13:20 AEDT
+            1_700_086_400, // 2023-11-15 22:13:20 UTC = 2023-11-16 09:13:20 AEDT
+            1_700_172_800, // 2023-11-16 22:13:20 UTC = 2023-11-17 09:13:20 AEDT
+        ],
+        Some(TimeUnit::Seconds),
+    );
+    let sydney_field_array = FieldArray::from_parts(
+        "event_time",
+        ArrowType::Timestamp(TimeUnit::Seconds, Some("Australia/Sydney".to_string())),
+        Some(false), // not nullable
+        None,        // no additional metadata
+        sydney_events.into(),
+    );
+
+    println!("   Field name: {}", sydney_field_array.field.name);
+    println!("   Field type: {:?}", sydney_field_array.field.dtype);
+    println!("   Data:");
+    sydney_field_array.print();
+
+    // Example 2: Multiple FieldArrays with different timezones
+    println!("\n2. Multiple FieldArrays with different timezones:");
+
+    // New York events (EST/EDT)
+    let ny_events = DatetimeArray::<i64>::from_slice(&[1_700_000_000, 1_700_086_400], Some(TimeUnit::Seconds));
+    let ny_field_array = FieldArray::from_parts(
+        "ny_time",
+        ArrowType::Timestamp(TimeUnit::Seconds, Some("America/New_York".to_string())),
+        Some(false),
+        None,
+        ny_events.into(),
+    );
+
+    // Tokyo events (JST)
+    let tokyo_events = DatetimeArray::<i64>::from_slice(&[1_700_000_000, 1_700_086_400], Some(TimeUnit::Seconds));
+    let tokyo_field_array = FieldArray::from_parts(
+        "tokyo_time",
+        ArrowType::Timestamp(TimeUnit::Seconds, Some("Asia/Tokyo".to_string())),
+        Some(false),
+        None,
+        tokyo_events.into(),
+    );
+
+    // Extract timezone from ArrowType for display
+    let ny_tz = if let ArrowType::Timestamp(_, Some(tz)) = &ny_field_array.field.dtype {
+        tz.as_str()
+    } else {
+        "UTC"
+    };
+    let tokyo_tz = if let ArrowType::Timestamp(_, Some(tz)) = &tokyo_field_array.field.dtype {
+        tz.as_str()
+    } else {
+        "UTC"
+    };
+
+    println!("\n   New York events ({}):", ny_tz);
+    ny_field_array.print();
+
+    println!("\n   Tokyo events ({}):", tokyo_tz);
+    tokyo_field_array.print();
+
+    println!("\n   Note: All FieldArrays contain the same UTC timestamps,");
+    println!("   but display in their respective local timezones based on ArrowType metadata.");
+
+    // Example 3: FieldArray with unusual offset
+    println!("\n3. FieldArray with unusual timezone offset:");
+    let nepal_events = DatetimeArray::<i64>::from_slice(&[1_700_000_000], Some(TimeUnit::Seconds));
+    let nepal_field_array = FieldArray::from_parts(
+        "nepal_event",
+        ArrowType::Timestamp(TimeUnit::Seconds, Some("Asia/Kathmandu".to_string())),
+        Some(false),
+        None,
+        nepal_events.into(),
+    );
+
+    println!("   Kathmandu uses +05:45 offset (Nepal Time):");
+    nepal_field_array.print();
+
+    // Type Casting
+    println!("\n--- Type Casting ---");
+
+    let as_millis = arr.cast_time_unit(TimeUnit::Milliseconds).unwrap();
+    println!("\nCast to milliseconds:");
+    for i in 0..as_millis.len() {
+        if let Some(dt) = as_millis.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+    let as_micros = arr.cast_time_unit(TimeUnit::Microseconds).unwrap();
+    println!("\nCast to microseconds:");
+    for i in 0..as_micros.len() {
+        if let Some(dt) = as_micros.as_datetime(i) {
+            println!("  [{}] {}", i, dt);
+        }
+    }
+
+
+    // Inline Timezone Operations
+    println!("\n--- Inline Timezone Operations ---");
+    println!("\nTimezone support includes:");
+    println!("  1. IANA timezone identifiers (e.g., 'Australia/Sydney')");
+    println!("  2. Timezone abbreviations (e.g., 'AEST', 'EST', 'JST')");
+    println!("  3. Direct offset strings (e.g., '+10:00', '-05:00')");
+
+    // Use the first timestamp for timezone examples
+    let utc_dt = DatetimeArray::<i64>::from_slice(&[timestamps[0]], Some(TimeUnit::Seconds));
+
+    println!("\nOriginal UTC time: 2023-11-14 22:13:20 UTC");
+    println!("\n1. IANA Timezone Identifiers:");
+    println!("   Australia/Sydney:");
+    utc_dt.tz("Australia/Sydney").print();
+    println!();
+
+    println!("   America/New_York:");
+    utc_dt.tz("America/New_York").print();
+    println!();
+
+    println!("   Europe/London:");
+    utc_dt.tz("Europe/London").print();
+    println!();
+
+    println!("   Asia/Tokyo:");
+    utc_dt.tz("Asia/Tokyo").print();
+    println!();
+
+    println!("   America/Los_Angeles:");
+    utc_dt.tz("America/Los_Angeles").print();
+    println!();
+
+    println!("\n2. Timezone Abbreviations:");
+    println!("   AEST (Australian Eastern Standard Time):");
+    utc_dt.tz("AEST").print();
+    println!();
+
+    println!("   EST (Eastern Standard Time):");
+    utc_dt.tz("EST").print();
+    println!();
+
+    println!("   JST (Japan Standard Time):");
+    utc_dt.tz("JST").print();
+    println!();
+
+    println!("   GMT (Greenwich Mean Time):");
+    utc_dt.tz("GMT").print();
+    println!();
+
+    println!("   PST (Pacific Standard Time):");
+    utc_dt.tz("PST").print();
+    println!();
+
+    println!("\n3. Direct Offset Strings:");
+    println!("   +10:00 (Eastern Australia):");
+    utc_dt.tz("+10:00").print();
+    println!();
+
+    println!("   -05:00 (US Eastern):");
+    utc_dt.tz("-05:00").print();
+    println!();
+
+    println!("   +05:30 (India Standard Time):");
+    utc_dt.tz("+05:30").print();
+    println!();
+
+    println!("   -03:30 (Newfoundland):");
+    utc_dt.tz("-03:30").print();
+    println!();
+
+    println!("   +09:00 (Japan):");
+    utc_dt.tz("+09:00").print();
+    println!();
+
+    // Demonstrate unusual offsets
+    println!("\n4. Unusual Timezone Offsets:");
+    println!("   Australia/Eucla (+08:45):");
+    utc_dt.tz("Australia/Eucla").print();
+    println!();
+
+    println!("   Asia/Kathmandu (+05:45):");
+    utc_dt.tz("Asia/Kathmandu").print();
+    println!();
+
+    println!("   Pacific/Chatham (+12:45):");
+    utc_dt.tz("Pacific/Chatham").print();
+    println!();
+
+    println!("\n  Example End.");
+}
+
+#[cfg(not(feature = "datetime_ops"))]
+fn main() {
+    eprintln!("This example requires the 'datetime_ops' feature.");
+    eprintln!("Run with: cargo run --example datetime_ops --features datetime_ops");
+}

--- a/examples/ffi/polars_ffi.rs
+++ b/examples/ffi/polars_ffi.rs
@@ -1,5 +1,5 @@
 //! ---------------------------------------------------------
-//! Minarrow ↔️ Polars (via polars_arrow/arrow2) FFI roundtrip
+//! Minarrow <->️ Polars (via polars_arrow/arrow2) FFI roundtrip
 //!
 //! Run with:
 //!    cargo run --example polars_ffi --features cast_polars

--- a/examples/print/print_arrays.rs
+++ b/examples/print/print_arrays.rs
@@ -15,7 +15,7 @@ use minarrow::{Bitmask, MaskedArray, NumericArray, Print, TextArray};
 use minarrow::{ArrayV, BitmaskV, NumericArrayV, TextArrayV};
 
 #[cfg(feature = "datetime")]
-use minarrow::{DatetimeArray, TemporalArray};
+use minarrow::DatetimeArray;
 
 fn main() {
     // Numeric (Integer, Float, all sizes)
@@ -36,33 +36,6 @@ fn main() {
             .copied(),
     );
 
-    // Datetime
-    #[cfg(feature = "datetime")]
-    let col_dt32 = DatetimeArray::<i32>::from_slice(
-        &[1000, 2000, 3000, 4000, 5000],
-        Some(minarrow::enums::time_units::TimeUnit::Milliseconds),
-    );
-    #[cfg(feature = "datetime")]
-    let col_dt64 = DatetimeArray::<i64>::from_slice(
-        &[
-            1_000_000_000,
-            2_000_000_000,
-            3_000_000_000,
-            4_000_000_000,
-            5_000_000_000,
-        ],
-        Some(minarrow::enums::time_units::TimeUnit::Nanoseconds),
-    );
-
-    #[cfg(feature = "datetime")]
-    col_dt32.print();
-    #[cfg(feature = "datetime")]
-    println!("\n");
-    #[cfg(feature = "datetime")]
-    col_dt64.print();
-    #[cfg(feature = "datetime")]
-    println!("\n");
-
     // --- Print NumericArray, TextArray, TemporalArray enums
     println!("\n--- Enums: NumericArray, TextArray, TemporalArray ---");
     NumericArray::Int32(Arc::new(col_i32.clone())).print();
@@ -75,15 +48,6 @@ fn main() {
     println!("\n");
     let _ = &TextArray::Categorical32(Arc::new(col_cat32.clone())).print();
 
-    println!("\n/ *** To display as dates, enable the optional 'chrono' feature *** /\n");
-
-    #[cfg(feature = "datetime")]
-    let _ = &TemporalArray::Datetime32(Arc::new(col_dt32.clone())).print();
-    println!("\n");
-    #[cfg(feature = "datetime")]
-    let _ = &TemporalArray::Datetime64(Arc::new(col_dt64.clone())).print();
-    println!("\n");
-
     println!("\n--- Array (top-level) ---");
     Array::from_int32(col_i32.clone()).print();
     println!("\n");
@@ -94,9 +58,6 @@ fn main() {
     Array::from_string32(col_str32.clone()).print();
     println!("\n");
     Array::from_categorical32(col_cat32.clone()).print();
-    println!("\n");
-    #[cfg(feature = "datetime")]
-    Array::from_datetime_i32(col_dt32.clone()).print();
     println!("\n");
     // --- Print Array Views (ArrayV, NumericArrayV, TextArrayV, TemporalArrayV)
     #[cfg(feature = "views")]
@@ -120,19 +81,149 @@ fn main() {
     #[cfg(feature = "views")]
     txt_view.print();
 
-    #[cfg(all(feature = "datetime", feature = "views"))]
-    {
-        use minarrow::TemporalArrayV;
-
-        let tmp_arr = TemporalArray::Datetime32(Arc::new(col_dt32.clone()));
-        tmp_arr.print();
-        TemporalArrayV::new(tmp_arr, 1, 3).print();
-    }
-
     // --- Print Bitmask and BitmaskV
     println!("\n--- Bitmask & BitmaskV ---");
     let bm = Bitmask::from_bools(&[true, false, true, true, false]);
     bm.print();
     #[cfg(feature = "views")]
     BitmaskV::new(bm.clone(), 1, 3).print();
+
+    // Datetime - various time units
+    #[cfg(feature = "datetime")]
+    {
+        use minarrow::enums::time_units::TimeUnit;
+
+        println!("\n--- Datetime Arrays (various time units) ---");
+
+        // Seconds since Unix epoch (1970-01-01 00:00:00 UTC)
+        let dt_seconds = DatetimeArray::<i64>::from_slice(
+            &[
+                1_700_000_000, // 2023-11-14 22:13:20 UTC
+                1_700_086_400, // 2023-11-15 22:13:20 UTC
+                1_700_172_800, // 2023-11-16 22:13:20 UTC
+            ],
+            Some(TimeUnit::Seconds),
+        );
+        println!("Seconds:");
+        dt_seconds.print();
+        println!();
+
+        // Milliseconds
+        let dt_millis = DatetimeArray::<i64>::from_slice(
+            &[
+                1_700_000_000_000, // 2023-11-14 22:13:20.000 UTC
+                1_700_086_400_000, // 2023-11-15 22:13:20.000 UTC
+                1_700_172_800_000, // 2023-11-16 22:13:20.000 UTC
+            ],
+            Some(TimeUnit::Milliseconds),
+        );
+        println!("Milliseconds:");
+        dt_millis.print();
+        println!();
+
+        // Microseconds
+        let dt_micros = DatetimeArray::<i64>::from_slice(
+            &[
+                1_700_000_000_000_000, // 2023-11-14 22:13:20.000000 UTC
+                1_700_086_400_000_000, // 2023-11-15 22:13:20.000000 UTC
+                1_700_172_800_000_000, // 2023-11-16 22:13:20.000000 UTC
+            ],
+            Some(TimeUnit::Microseconds),
+        );
+        println!("Microseconds:");
+        dt_micros.print();
+        println!();
+
+        // Nanoseconds
+        let dt_nanos = DatetimeArray::<i64>::from_slice(
+            &[
+                1_700_000_000_000_000_000, // 2023-11-14 22:13:20.000000000 UTC
+                1_700_086_400_000_000_000, // 2023-11-15 22:13:20.000000000 UTC
+                1_700_172_800_000_000_000, // 2023-11-16 22:13:20.000000000 UTC
+            ],
+            Some(TimeUnit::Nanoseconds),
+        );
+        println!("Nanoseconds:");
+        dt_nanos.print();
+        println!();
+
+        // Days since Unix epoch
+        let dt_days = DatetimeArray::<i32>::from_slice(
+            &[
+                19_670, // 2023-11-14
+                19_671, // 2023-11-15
+                19_672, // 2023-11-16
+            ],
+            Some(TimeUnit::Days),
+        );
+        println!("Days:");
+        dt_days.print();
+        println!();
+
+        // With timezone operations (requires datetime_ops feature)
+        #[cfg(feature = "datetime_ops")]
+        {
+            println!(
+                "--- Datetime with Timezone Conversions (requires 'datetime_ops' feature) ---"
+            );
+
+            // UTC datetime
+            let utc_dt =
+                DatetimeArray::<i64>::from_slice(&[1_700_000_000], Some(TimeUnit::Seconds));
+
+            // Test IANA timezone identifiers
+            println!("IANA Timezone Identifiers:");
+            println!("America/New_York:");
+            utc_dt.tz("America/New_York").print();
+            println!();
+
+            println!("Australia/Sydney:");
+            utc_dt.tz("Australia/Sydney").print();
+            println!();
+
+            println!("Europe/London:");
+            utc_dt.tz("Europe/London").print();
+            println!();
+
+            println!("Asia/Tokyo:");
+            utc_dt.tz("Asia/Tokyo").print();
+            println!();
+
+            // Test timezone abbreviations
+            println!("\nTimezone Abbreviations:");
+            println!("EST:");
+            utc_dt.tz("EST").print();
+            println!();
+
+            println!("AEST:");
+            utc_dt.tz("AEST").print();
+            println!();
+
+            println!("JST:");
+            utc_dt.tz("JST").print();
+            println!();
+
+            // Test direct offset strings
+            println!("\nDirect Offset Strings:");
+            println!("UTC:");
+            utc_dt.tz("UTC").print();
+            println!();
+
+            println!("+05:30 (India):");
+            utc_dt.tz("+05:30").print();
+            println!();
+
+            println!("-03:30 (Newfoundland):");
+            utc_dt.tz("-03:30").print();
+            println!();
+        }
+
+        #[cfg(not(feature = "datetime_ops"))]
+        {
+            println!(
+                "Note: Enable 'datetime_ops' feature for timezone conversions and datetime operations."
+            );
+            println!();
+        }
+    }
 }

--- a/examples/print/print_table.rs
+++ b/examples/print/print_table.rs
@@ -52,19 +52,19 @@ fn main() {
     );
 
     // FieldArray (column) construction
-    let fa_i32 = FieldArray::from_inner("int32_col", col_i32);
-    let fa_u32 = FieldArray::from_inner("uint32_col", col_u32);
-    let fa_i64 = FieldArray::from_inner("int64_col", col_i64);
-    let fa_u64 = FieldArray::from_inner("uint64_col", col_u64);
-    let fa_f32 = FieldArray::from_inner("float32_col", col_f32);
-    let fa_f64 = FieldArray::from_inner("float64_col", col_f64);
-    let fa_bool = FieldArray::from_inner("bool_col", col_bool);
-    let fa_str32 = FieldArray::from_inner("utf8_col", col_str32);
-    let fa_cat32 = FieldArray::from_inner("dict32_col", col_cat32);
+    let fa_i32 = FieldArray::from_arr("int32_col", col_i32);
+    let fa_u32 = FieldArray::from_arr("uint32_col", col_u32);
+    let fa_i64 = FieldArray::from_arr("int64_col", col_i64);
+    let fa_u64 = FieldArray::from_arr("uint64_col", col_u64);
+    let fa_f32 = FieldArray::from_arr("float32_col", col_f32);
+    let fa_f64 = FieldArray::from_arr("float64_col", col_f64);
+    let fa_bool = FieldArray::from_arr("bool_col", col_bool);
+    let fa_str32 = FieldArray::from_arr("utf8_col", col_str32);
+    let fa_cat32 = FieldArray::from_arr("dict32_col", col_cat32);
     #[cfg(feature = "datetime")]
-    let fa_dt32 = FieldArray::from_inner("datetime32_col", col_dt32);
+    let fa_dt32 = FieldArray::from_arr("datetime32_col", col_dt32);
     #[cfg(feature = "datetime")]
-    let fa_dt64 = FieldArray::from_inner("datetime64_col", col_dt64);
+    let fa_dt64 = FieldArray::from_arr("datetime64_col", col_dt64);
 
     // Build Table
     let mut tbl = Table::new("MyTable".to_string(), None);

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -71,8 +71,8 @@ use crate::SuperTable;
 /// ```rust
 /// use minarrow::{arr_i32, arr_str32, FieldArray, Print, vec64, aliases::RecordBatch};
 ///
-/// let col1 = FieldArray::from_inner("numbers", arr_i32![1, 2, 3]);
-/// let col2 = FieldArray::from_inner("letters", arr_str32!["x", "y", "z"]);
+/// let col1 = FieldArray::from_arr("numbers", arr_i32![1, 2, 3]);
+/// let col2 = FieldArray::from_arr("letters", arr_str32!["x", "y", "z"]);
 ///
 /// let mut tbl = RecordBatch::new("Demo".into(), vec![col1, col2].into());
 /// tbl.print();

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -4,20 +4,20 @@
 //! unified [`Array`] enum, plus `View` impls where the `views` feature is enabled.
 //!
 //! ## What’s included
-//! - **Numeric ↔ Numeric**
+//! - **Numeric <-> Numeric**
 //!   - *Widening* `From<&IntegerArray<S>> for IntegerArray<D>` and `From<&IntegerArray<S>> for FloatArray<D>`.
 //!   - *Narrowing / signedness changes* via `TryFrom<&IntegerArray<S>> for IntegerArray<D>` with
 //!     [`MinarrowError::Overflow`] on out-of-range values.
-//! - **Float ↔ Integer**
+//! - **Float <-> Integer**
 //!   - `TryFrom<&FloatArray<F>> for IntegerArray<I>` with strict checks (finite + exact truncation);
 ////!     returns [`MinarrowError::LossyCast`] if fidelity is lost.
-//! - **Booleans ↔ Primitives**
+//! - **Booleans <-> Primitives**
 //!   - `From<&BooleanArray<u8>>` to integer/float (true→1/1.0, false→0/0.0).
 //!   - `From<&IntegerArray<T>>` / `From<&FloatArray<T>>` to `BooleanArray<u8>` (non-zero → true).
 //! - **Numerics/Booleans → Strings**
 //!   - `From<&IntegerArray<T>>`, `From<&FloatArray<T>>`, and `From<&BooleanArray<u8>>` to
 //!     `StringArray<u32>` (UTF-8), preserving null masks.
-//! - **Strings ↔ Categoricals**
+//! - **Strings <-> Categoricals**
 //!   - `TryFrom<&StringArray<Off>> for CategoricalArray<Idx>` builds a dictionary with stable codes.
 //!   - `TryFrom<&CategoricalArray<Idx>> for StringArray<Off>` materialises codes back to UTF-8.
 //!   - Widening/narrowing categorical index conversions (`From`/`TryFrom`) with overflow checks.

--- a/src/enums/time_units.rs
+++ b/src/enums/time_units.rs
@@ -24,7 +24,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 /// ## Behaviour
 /// - Unit values are stored on the `DatetimeArray`, enabling variant-specific logic.
 /// - When transmitted over FFI, an `Apache Arrow`- produces compatible native format.
-#[derive(PartialEq, Clone, Debug, Default)]
+#[derive(PartialEq, Clone, Copy, Debug, Default)]
 pub enum TimeUnit {
     /// Seconds for Apache Arrow `Time32` and `Time64` units.
     Seconds,

--- a/src/ffi/arrow_dtype.rs
+++ b/src/ffi/arrow_dtype.rs
@@ -94,7 +94,7 @@ pub enum ArrowType {
     #[cfg(feature = "datetime")]
     Duration64(TimeUnit),
     #[cfg(feature = "datetime")]
-    Timestamp(TimeUnit),
+    Timestamp(TimeUnit, Option<String>), // TimeUnit + optional timezone string (e.g., "UTC", "America/New_York")
     #[cfg(feature = "datetime")]
     Interval(IntervalUnit),
     String,
@@ -259,7 +259,13 @@ impl Display for ArrowType {
             #[cfg(feature = "datetime")]
             ArrowType::Duration64(unit) => write!(f, "Duration64({unit})"),
             #[cfg(feature = "datetime")]
-            ArrowType::Timestamp(unit) => write!(f, "Timestamp({unit})"),
+            ArrowType::Timestamp(unit, tz) => {
+                if let Some(tz_str) = tz {
+                    write!(f, "Timestamp({unit}, {})", tz_str)
+                } else {
+                    write!(f, "Timestamp({unit})")
+                }
+            }
             #[cfg(feature = "datetime")]
             ArrowType::Interval(interval) => write!(f, "Interval({interval})"),
 

--- a/src/kernels/arithmetic/types.rs
+++ b/src/kernels/arithmetic/types.rs
@@ -1222,11 +1222,11 @@ mod tests {
     #[test]
     fn test_value_table_addition() {
         // Create first table: columns [1, 2, 3] and [10, 20, 30]
-        let col1_a = FieldArray::from_inner(
+        let col1_a = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![1, 2, 3])),
         );
-        let col2_a = FieldArray::from_inner(
+        let col2_a = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![10, 20, 30])),
         );
@@ -1236,11 +1236,11 @@ mod tests {
         )));
 
         // Create second table: columns [4, 5, 6] and [40, 50, 60]
-        let col1_b = FieldArray::from_inner(
+        let col1_b = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![4, 5, 6])),
         );
-        let col2_b = FieldArray::from_inner(
+        let col2_b = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![40, 50, 60])),
         );
@@ -1290,11 +1290,11 @@ mod tests {
         use crate::TableV;
 
         // Create first table: columns [1, 2, 3] and [10, 20, 30]
-        let col1_a = FieldArray::from_inner(
+        let col1_a = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![1, 2, 3])),
         );
-        let col2_a = FieldArray::from_inner(
+        let col2_a = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![10, 20, 30])),
         );
@@ -1302,11 +1302,11 @@ mod tests {
         let table_view_a = Value::TableView(Arc::new(TableV::from(table_a)));
 
         // Create second table: columns [4, 5, 6] and [40, 50, 60]
-        let col1_b = FieldArray::from_inner(
+        let col1_b = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![4, 5, 6])),
         );
-        let col2_b = FieldArray::from_inner(
+        let col2_b = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![40, 50, 60])),
         );

--- a/src/kernels/broadcast/cube.rs
+++ b/src/kernels/broadcast/cube.rs
@@ -1067,11 +1067,11 @@ mod tests {
 
     fn create_test_table(name: &str, base_val: i32) -> Table {
         // Create a simple table with 2 columns and 2 rows
-        let col1 = FieldArray::from_inner(
+        let col1 = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![base_val, base_val + 1])),
         );
-        let col2 = FieldArray::from_inner(
+        let col2 = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![
                 base_val * 10,

--- a/src/kernels/broadcast/mod.rs
+++ b/src/kernels/broadcast/mod.rs
@@ -132,7 +132,7 @@ pub fn value_power(lhs: Value, rhs: Value) -> Result<Value, MinarrowError> {
 }
 
 /// Implementation of Add operation for Value enum following the unified pattern
-/// 
+///
 /// # Notes:
 /// 1.⚠️ Best to keep this out of the binary by disabling value_type unless you
 /// require universal broadcasting compatibility.
@@ -563,7 +563,7 @@ pub fn broadcast_value(
                 .map(|tbl| Value::Table(Arc::new(tbl)))
         }
 
-        // Use the optimized TableView broadcasting function
+        // Use the optimised TableView broadcasting function
         #[cfg(feature = "views")]
         (Value::TableView(l), Value::TableView(r)) => {
             broadcast_tableview_to_tableview(op, &l, &r)

--- a/src/kernels/broadcast/table.rs
+++ b/src/kernels/broadcast/table.rs
@@ -379,13 +379,13 @@ mod tests {
     use crate::{Array, FieldArray, IntegerArray, vec64};
 
     fn create_test_table(name: &str, data1: &[i32], data2: &[i32]) -> Table {
-        let col1 = FieldArray::from_inner(
+        let col1 = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![
                 data1[0], data1[1], data1[2]
             ])),
         );
-        let col2 = FieldArray::from_inner(
+        let col2 = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![
                 data2[0], data2[1], data2[2]
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "column count mismatch")]
     fn test_mismatched_column_count() {
-        let col1 = FieldArray::from_inner(
+        let col1 = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![1, 2, 3])),
         );
@@ -446,11 +446,11 @@ mod tests {
     #[test]
     #[should_panic(expected = "row count mismatch")]
     fn test_mismatched_row_count() {
-        let col1 = FieldArray::from_inner(
+        let col1 = FieldArray::from_arr(
             "col1",
             Array::from_int32(IntegerArray::from_slice(&vec64![1, 2])),
         );
-        let col2 = FieldArray::from_inner(
+        let col2 = FieldArray::from_arr(
             "col2",
             Array::from_int32(IntegerArray::from_slice(&vec64![10, 20])),
         );

--- a/src/structs/buffer.rs
+++ b/src/structs/buffer.rs
@@ -599,7 +599,6 @@ impl<T> AsMut<[T]> for Buffer<T> {
 
 #[cfg(feature = "parallel_proc")]
 impl<T: Send + Sync> Buffer<T> {
-    
     #[inline]
     pub fn par_iter(&self) -> rayon::slice::Iter<'_, T> {
         use rayon::iter::IntoParallelRefIterator;

--- a/src/structs/matrix.rs
+++ b/src/structs/matrix.rs
@@ -6,7 +6,6 @@
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::Table;
 use crate::enums::error::MinarrowError;
 use crate::enums::shape_dim::ShapeDim;
 use crate::traits::{concatenate::Concatenate, shape::Shape};

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -69,8 +69,8 @@ static UNNAMED_COUNTER: AtomicUsize = AtomicUsize::new(1);
 /// ```rust
 /// use minarrow::{FieldArray, Print, Table, arr_i32, arr_str32, vec64};
 ///
-/// let col1 = FieldArray::from_inner("numbers", arr_i32![1, 2, 3]);
-/// let col2 = FieldArray::from_inner("letters", arr_str32!["x", "y", "z"]);
+/// let col1 = FieldArray::from_arr("numbers", arr_i32![1, 2, 3]);
+/// let col2 = FieldArray::from_arr("letters", arr_str32!["x", "y", "z"]);
 ///
 /// let mut tbl = Table::new("Demo".into(), vec![col1, col2].into());
 /// tbl.print();

--- a/src/structs/variants/datetime/datetime_ops.rs
+++ b/src/structs/variants/datetime/datetime_ops.rs
@@ -1,0 +1,1553 @@
+//! # **DatetimeOps Module** - *Datetime Operations for DatetimeArray*
+//!
+//! Datetime operations for `DatetimeArray` built on the `time` crate.
+//!
+//! ## Features
+//! - **Arithmetic**: add/subtract durations, days, months, years with overflow checking
+//! - **Duration calculations**: diff and absolute diff between datetime arrays
+//! - **Comparisons**: temporal ordering (before/after) and range checks (between)
+//! - **Component extraction**: year, month, day, hour, minute, second, weekday, quarter, ISO week
+//! - **Truncation**: round down to year, month, week, day, hour, minute, second, or sub-second boundaries
+//! - **Type casting**: convert between time units (seconds <-> milliseconds <-> microseconds <-> nanoseconds)
+//!
+//! ## Timezone Handling
+//! `DatetimeArray` stores raw UTC timestamps as integers. Timezone information is metadata-only
+//! and stored in `ArrowType::Timestamp(TimeUnit, Option<String>)` on the `Field` level.
+//! For timezone operations, use `FieldArray::with_timezone()` and `FieldArray::to_utc()` which
+//! update metadata without modifying the underlying UTC data.
+//!
+//! ## Requirements
+//! Requires the `time` feature to be enabled.
+
+#[cfg(feature = "datetime_ops")]
+use time::Duration;
+
+#[cfg(feature = "datetime_ops")]
+use crate::{
+    DatetimeArray,
+    enums::{error::MinarrowError, time_units::TimeUnit},
+    structs::variants::{boolean::BooleanArray, integer::IntegerArray},
+    traits::{masked_array::MaskedArray, type_unions::Integer},
+};
+#[cfg(feature = "datetime_ops")]
+use num_traits::FromPrimitive;
+
+#[cfg(feature = "datetime_ops")]
+impl<T: Integer + FromPrimitive> DatetimeArray<T> {
+    /// Convert i64 value to OffsetDateTime based on time unit.
+    #[inline(always)]
+    fn i64_to_datetime(val_i64: i64, time_unit: TimeUnit) -> Option<time::OffsetDateTime> {
+        use time::OffsetDateTime;
+        match time_unit {
+            TimeUnit::Seconds => OffsetDateTime::from_unix_timestamp(val_i64).ok(),
+            TimeUnit::Milliseconds => {
+                OffsetDateTime::from_unix_timestamp_nanos((val_i64 as i128) * 1_000_000).ok()
+            }
+            TimeUnit::Microseconds => {
+                OffsetDateTime::from_unix_timestamp_nanos((val_i64 as i128) * 1_000).ok()
+            }
+            TimeUnit::Nanoseconds => {
+                OffsetDateTime::from_unix_timestamp_nanos(val_i64 as i128).ok()
+            }
+            TimeUnit::Days => time::Date::from_julian_day((val_i64 + 2440588) as i32)
+                .ok()
+                .and_then(|date| date.with_hms(0, 0, 0).ok())
+                .map(|dt| dt.assume_utc()),
+        }
+    }
+
+    /// Convert OffsetDateTime back to i64 value based on time unit.
+    #[inline(always)]
+    fn datetime_to_i64(dt: time::OffsetDateTime, time_unit: TimeUnit) -> i64 {
+        match time_unit {
+            TimeUnit::Seconds => dt.unix_timestamp(),
+            TimeUnit::Milliseconds => {
+                dt.unix_timestamp() * 1_000i64 + (dt.nanosecond() / 1_000_000) as i64
+            }
+            TimeUnit::Microseconds => {
+                dt.unix_timestamp() * 1_000_000i64 + (dt.nanosecond() / 1_000) as i64
+            }
+            TimeUnit::Nanoseconds => {
+                dt.unix_timestamp() * 1_000_000_000i64 + dt.nanosecond() as i64
+            }
+            TimeUnit::Days => dt.unix_timestamp() / 86400i64,
+        }
+    }
+
+    /// Helper to convert a value at index to OffsetDateTime.
+    ///
+    /// Performs bounds and null checks. For hot loops, prefer direct i64 conversion
+    /// with `i64_to_datetime` after manual validation.
+    fn value_to_datetime(&self, i: usize) -> Option<time::OffsetDateTime> {
+        if self.is_null(i) || i >= self.len() {
+            return None;
+        }
+        let val_i64 = self.data[i].to_i64()?;
+        Self::i64_to_datetime(val_i64, self.time_unit)
+    }
+
+    // Arithmetic Operations
+
+    /// Adds a duration to all datetime values in the array.
+    ///
+    /// # Example
+    /// ```ignore
+    /// use minarrow::{DatetimeArray, TimeUnit};
+    /// use time::Duration;
+    ///
+    /// let arr = DatetimeArray::<i64>::from_slice(&[1000, 2000], Some(TimeUnit::Milliseconds));
+    /// let result = arr.add_duration(Duration::seconds(5)).unwrap();
+    /// ```
+    pub fn add_duration(&self, duration: Duration) -> Result<Self, MinarrowError> {
+        let mut result = self.clone();
+        let len = result.len();
+        let data = &self.data[..];
+
+        // Convert duration to the array's time unit
+        let duration_value: i64 =
+            match self.time_unit {
+                TimeUnit::Seconds => duration.whole_seconds(),
+                TimeUnit::Milliseconds => {
+                    duration.whole_milliseconds().try_into().map_err(|_| {
+                        MinarrowError::Overflow {
+                            value: format!("{} ms", duration.whole_milliseconds()),
+                            target: "i64",
+                        }
+                    })?
+                }
+                TimeUnit::Microseconds => {
+                    duration.whole_microseconds().try_into().map_err(|_| {
+                        MinarrowError::Overflow {
+                            value: format!("{} μs", duration.whole_microseconds()),
+                            target: "i64",
+                        }
+                    })?
+                }
+                TimeUnit::Nanoseconds => duration.whole_nanoseconds().try_into().map_err(|_| {
+                    MinarrowError::Overflow {
+                        value: format!("{} ns", duration.whole_nanoseconds()),
+                        target: "i64",
+                    }
+                })?,
+                TimeUnit::Days => duration.whole_days(),
+            };
+
+        for i in 0..len {
+            if !self.is_null(i) {
+                // SAFETY: i is bounded by len, so access is safe
+                let val = unsafe { *data.get_unchecked(i) };
+
+                if let Some(val_i64) = val.to_i64() {
+                    if let Some(new_val_i64) = val_i64.checked_add(duration_value) {
+                        if let Some(new_val_t) = T::from_i64(new_val_i64) {
+                            result.set(i, new_val_t);
+                        } else {
+                            result.set_null(i);
+                        }
+                    } else {
+                        result.set_null(i); // Overflow
+                    }
+                } else {
+                    result.set_null(i);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Subtracts a duration from all datetime values in the array.
+    pub fn sub_duration(&self, duration: Duration) -> Result<Self, MinarrowError> {
+        self.add_duration(-duration)
+    }
+
+    /// Adds a number of days to all datetime values.
+    pub fn add_days(&self, days: i64) -> Result<Self, MinarrowError> {
+        self.add_duration(Duration::days(days))
+    }
+
+    /// Adds a number of months to all datetime values.
+    ///
+    /// Variable month length handling - if the day would be invalid in the target month
+    /// (e.g., Jan 31 + 1 month), the day is clamped to the last valid day (Feb 28/29).
+    /// Time-of-day is preserved.
+    pub fn add_months(&self, months: i32) -> Result<Self, MinarrowError> {
+        let mut result = self.clone();
+        let len = result.len();
+        let data = &self.data[..];
+        let time_unit = self.time_unit; // Hoist time_unit outside loop
+
+        for i in 0..len {
+            if !self.is_null(i) {
+                // SAFETY: i is bounded by len
+                let val = unsafe { *data.get_unchecked(i) };
+
+                if let Some(val_i64) = val.to_i64() {
+                    if let Some(dt) = Self::i64_to_datetime(val_i64, time_unit) {
+                        let date = dt.date();
+
+                        // Calculate new year and month
+                        let total_months = date.year() * 12 + (date.month() as i32) - 1 + months;
+                        let new_year = total_months / 12;
+                        let new_month = (total_months % 12 + 1) as u8;
+
+                        // Try to construct new date
+                        if let Ok(new_month_enum) = time::Month::try_from(new_month) {
+                            let days_in_month = new_month_enum.length(new_year);
+                            let day = date.day().min(days_in_month);
+                            if let Ok(new_date) =
+                                time::Date::from_calendar_date(new_year, new_month_enum, day)
+                            {
+                                let new_dt_primitive = new_date.with_time(dt.time());
+                                let new_dt = new_dt_primitive.assume_utc();
+                                let new_val_i64 = Self::datetime_to_i64(new_dt, time_unit);
+
+                                if let Some(new_val_t) = T::from_i64(new_val_i64) {
+                                    result.set(i, new_val_t);
+                                } else {
+                                    result.set_null(i);
+                                }
+                            } else {
+                                result.set_null(i);
+                            }
+                        } else {
+                            result.set_null(i);
+                        }
+                    } else {
+                        result.set_null(i);
+                    }
+                } else {
+                    result.set_null(i);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Adds a number of years to all datetime values.
+    pub fn add_years(&self, years: i32) -> Result<Self, MinarrowError> {
+        self.add_months(years * 12)
+    }
+
+    // Duration Operations
+
+    /// Calculate the duration between this datetime array and another.
+    /// Returns an IntegerArray<i64> representing the difference in the specified unit.
+    ///
+    /// # Arguments
+    /// * `other` - The datetime array to subtract from self
+    /// * `unit` - The TimeUnit for the result (Seconds, Milliseconds, Microseconds, Nanoseconds)
+    pub fn diff(&self, other: &Self, unit: TimeUnit) -> Result<IntegerArray<i64>, MinarrowError> {
+        if self.len() != other.len() {
+            return Err(MinarrowError::TypeError {
+                from: "DatetimeArray",
+                to: "IntegerArray",
+                message: Some(format!(
+                    "Array lengths do not match: {} vs {}",
+                    self.len(),
+                    other.len()
+                )),
+            });
+        }
+
+        let mut result =
+            IntegerArray::with_capacity(self.len(), self.is_nullable() || other.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) || other.is_null(i) {
+                result.push_null();
+            } else {
+                let self_dt = self.value_to_datetime(i);
+                let other_dt = other.value_to_datetime(i);
+
+                if let (Some(a), Some(b)) = (self_dt, other_dt) {
+                    let diff_duration = a - b;
+
+                    let diff_value = match unit {
+                        TimeUnit::Seconds => diff_duration.whole_seconds(),
+                        TimeUnit::Milliseconds => diff_duration.whole_milliseconds() as i64,
+                        TimeUnit::Microseconds => diff_duration.whole_microseconds() as i64,
+                        TimeUnit::Nanoseconds => diff_duration.whole_nanoseconds() as i64,
+                        TimeUnit::Days => diff_duration.whole_days(),
+                    };
+
+                    result.push(diff_value);
+                } else {
+                    result.push_null();
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Calculate the absolute duration between elements (always positive).
+    pub fn abs_diff(
+        &self,
+        other: &Self,
+        unit: TimeUnit,
+    ) -> Result<IntegerArray<i64>, MinarrowError> {
+        let diff = self.diff(other, unit)?;
+        let mut result = IntegerArray::with_capacity(diff.len(), diff.is_nullable());
+
+        for i in 0..diff.len() {
+            if diff.is_null(i) {
+                result.push_null();
+            } else {
+                result.push(diff.data[i].abs());
+            }
+        }
+
+        Ok(result)
+    }
+
+    // Comparison Operations
+
+    /// Compares this array with another, returning a boolean array indicating
+    /// where values in `self` are before values in `other`.
+    pub fn is_before(&self, other: &Self) -> Result<BooleanArray<()>, MinarrowError> {
+        if self.len() != other.len() {
+            return Err(MinarrowError::TypeError {
+                from: "DatetimeArray",
+                to: "BooleanArray",
+                message: Some(format!(
+                    "Array lengths do not match: {} vs {}",
+                    self.len(),
+                    other.len()
+                )),
+            });
+        }
+
+        let mut result = BooleanArray::with_capacity(self.len(), true);
+
+        for i in 0..self.len() {
+            if self.is_null(i) || other.is_null(i) {
+                result.push_null();
+            } else {
+                let self_dt = self.value_to_datetime(i);
+                let other_dt = other.value_to_datetime(i);
+
+                if let (Some(a), Some(b)) = (self_dt, other_dt) {
+                    result.push(if a < b { true } else { false });
+                } else {
+                    result.push_null();
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Returns a boolean array indicating where values are after `other`.
+    pub fn is_after(&self, other: &Self) -> Result<BooleanArray<()>, MinarrowError> {
+        if self.len() != other.len() {
+            return Err(MinarrowError::TypeError {
+                from: "DatetimeArray",
+                to: "BooleanArray",
+                message: Some(format!(
+                    "Array lengths do not match: {} vs {}",
+                    self.len(),
+                    other.len()
+                )),
+            });
+        }
+
+        let mut result = BooleanArray::with_capacity(self.len(), true);
+
+        for i in 0..self.len() {
+            if self.is_null(i) || other.is_null(i) {
+                result.push_null();
+            } else {
+                let self_dt = self.value_to_datetime(i);
+                let other_dt = other.value_to_datetime(i);
+
+                if let (Some(a), Some(b)) = (self_dt, other_dt) {
+                    result.push(if a > b { true } else { false });
+                } else {
+                    result.push_null();
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Returns a boolean array indicating where values fall within the range [start, end].
+    pub fn between(&self, start: &Self, end: &Self) -> Result<BooleanArray<()>, MinarrowError> {
+        if self.len() != start.len() || self.len() != end.len() {
+            return Err(MinarrowError::TypeError {
+                from: "DatetimeArray",
+                to: "BooleanArray",
+                message: Some("Array lengths do not match".to_string()),
+            });
+        }
+
+        let mut result = BooleanArray::with_capacity(self.len(), true);
+
+        for i in 0..self.len() {
+            if self.is_null(i) || start.is_null(i) || end.is_null(i) {
+                result.push_null();
+            } else {
+                let self_dt = self.value_to_datetime(i);
+                let start_dt = start.value_to_datetime(i);
+                let end_dt = end.value_to_datetime(i);
+
+                if let (Some(val), Some(s), Some(e)) = (self_dt, start_dt, end_dt) {
+                    result.push(if val >= s && val <= e { true } else { false });
+                } else {
+                    result.push_null();
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    // Component Extraction Operations
+
+    /// Extracts the year component from all datetime values.
+    pub fn year(&self) -> IntegerArray<i32> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.year());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the month component (1-12) from all datetime values.
+    pub fn month(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.month() as u8);
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the day of month (1-31) from all datetime values.
+    pub fn day(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.day());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the hour component (0-23) from all datetime values.
+    pub fn hour(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.hour());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the minute component (0-59) from all datetime values.
+    pub fn minute(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.minute());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the second component (0-59) from all datetime values.
+    pub fn second(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.second());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the weekday (1=Sunday, 2=Monday, ..., 7=Saturday) from all datetime values.
+    pub fn weekday(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.weekday().number_from_sunday());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the day of year (1-366) from all datetime values.
+    pub fn day_of_year(&self) -> IntegerArray<u16> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.ordinal());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the ISO week number (1-53) from all datetime values.
+    pub fn iso_week(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                result.push(dt.iso_week());
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the quarter (1-4) from all datetime values.
+    pub fn quarter(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                let month = dt.month() as u8;
+                let quarter = ((month - 1) / 3) + 1;
+                result.push(quarter);
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Extracts the week of year (0-53) from all datetime values.
+    /// Week 0 contains days before the first Sunday.
+    pub fn week_of_year(&self) -> IntegerArray<u8> {
+        let mut result = IntegerArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                let day_of_year = dt.ordinal();
+                let weekday = dt.weekday().number_from_sunday();
+                // Calculate week based on day of year and weekday (Sunday = 1)
+                let week = ((day_of_year + 7 - weekday as u16) / 7) as u8;
+                result.push(week);
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    /// Returns boolean array indicating whether each datetime's year is a leap year.
+    pub fn is_leap_year(&self) -> BooleanArray<()> {
+        let mut result = BooleanArray::with_capacity(self.len(), self.is_nullable());
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                let year = dt.year();
+                let is_leap = time::util::is_leap_year(year);
+                result.push(is_leap);
+            } else {
+                result.push_null();
+            }
+        }
+
+        result
+    }
+
+    // Rounding/Truncating Operations
+
+    /// Truncate/floor datetime values to the start of the specified unit.
+    ///
+    /// # Arguments
+    /// * `unit` - The unit to truncate to (Day, Hour, Minute, Second)
+    pub fn truncate(&self, unit: &str) -> Result<Self, MinarrowError> {
+        let mut result = self.clone();
+        let len = result.len();
+        let time_unit = self.time_unit; // Hoist time_unit outside loop
+
+        for i in 0..len {
+            if !self.is_null(i) {
+                if let Some(val_i64) = self.data[i].to_i64() {
+                    if let Some(dt) = Self::i64_to_datetime(val_i64, time_unit) {
+                        let truncated_dt = match unit {
+                            "year" => {
+                                time::Date::from_calendar_date(dt.year(), time::Month::January, 1)
+                                    .ok()
+                                    .and_then(|d| d.with_hms(0, 0, 0).ok())
+                                    .map(|pdt| pdt.assume_utc())
+                            }
+                            "month" => time::Date::from_calendar_date(dt.year(), dt.month(), 1)
+                                .ok()
+                                .and_then(|d| d.with_hms(0, 0, 0).ok())
+                                .map(|pdt| pdt.assume_utc()),
+                            "day" => dt.date().with_hms(0, 0, 0).ok().map(|pdt| pdt.assume_utc()),
+                            "hour" => dt
+                                .date()
+                                .with_hms(dt.hour(), 0, 0)
+                                .ok()
+                                .map(|pdt| pdt.assume_utc()),
+                            "minute" => dt
+                                .date()
+                                .with_hms(dt.hour(), dt.minute(), 0)
+                                .ok()
+                                .map(|pdt| pdt.assume_utc()),
+                            "second" => dt
+                                .date()
+                                .with_hms(dt.hour(), dt.minute(), dt.second())
+                                .ok()
+                                .map(|pdt| pdt.assume_utc()),
+                            _ => {
+                                return Err(MinarrowError::TypeError {
+                                    from: "String",
+                                    to: "TimeUnit",
+                                    message: Some(format!("Invalid truncation unit: {}", unit)),
+                                });
+                            }
+                        };
+
+                        if let Some(new_dt) = truncated_dt {
+                            let new_val_i64 = Self::datetime_to_i64(new_dt, time_unit);
+                            if let Some(new_val_t) = T::from_i64(new_val_i64) {
+                                result.set(i, new_val_t);
+                            } else {
+                                result.set_null(i);
+                            }
+                        } else {
+                            result.set_null(i);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    // Truncation Shorthand Methods
+
+    /// Truncate to microsecond boundaries.
+    ///
+    /// Only meaningful for nanosecond precision arrays.
+    pub fn us(&self) -> Self {
+        let mut result = self.clone();
+
+        // Only meaningful for nanosecond precision
+        if self.time_unit == TimeUnit::Nanoseconds {
+            let len = result.len();
+            let data = &self.data[..];
+
+            for i in 0..len {
+                if !self.is_null(i) {
+                    // SAFETY: i is bounded by len
+                    let val = unsafe { *data.get_unchecked(i) };
+                    if let Some(val_i64) = val.to_i64() {
+                        // Truncate to microseconds (1000 nanoseconds)
+                        let truncated = (val_i64 / 1_000) * 1_000;
+                        if let Some(new_val_t) = T::from_i64(truncated) {
+                            result.set(i, new_val_t);
+                        }
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Truncate to millisecond boundaries.
+    ///
+    /// Meaningful for nanosecond and microsecond precision arrays.
+    pub fn ms(&self) -> Self {
+        let mut result = self.clone();
+        let len = result.len();
+        let data = &self.data[..];
+
+        match self.time_unit {
+            TimeUnit::Nanoseconds => {
+                for i in 0..len {
+                    if !self.is_null(i) {
+                        // SAFETY: i is bounded by len
+                        let val = unsafe { *data.get_unchecked(i) };
+                        if let Some(val_i64) = val.to_i64() {
+                            // Truncate to milliseconds (1_000_000 nanoseconds)
+                            let truncated = (val_i64 / 1_000_000) * 1_000_000;
+                            if let Some(new_val_t) = T::from_i64(truncated) {
+                                result.set(i, new_val_t);
+                            }
+                        }
+                    }
+                }
+            }
+            TimeUnit::Microseconds => {
+                for i in 0..len {
+                    if !self.is_null(i) {
+                        // SAFETY: i is bounded by len
+                        let val = unsafe { *data.get_unchecked(i) };
+                        if let Some(val_i64) = val.to_i64() {
+                            // Truncate to milliseconds (1_000 microseconds)
+                            let truncated = (val_i64 / 1_000) * 1_000;
+                            if let Some(new_val_t) = T::from_i64(truncated) {
+                                result.set(i, new_val_t);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        result
+    }
+
+    /// Truncate to second boundaries.
+    pub fn sec(&self) -> Self {
+        self.truncate("second").unwrap_or_else(|_| self.clone())
+    }
+
+    /// Truncate to minute boundaries.
+    pub fn min(&self) -> Self {
+        self.truncate("minute").unwrap_or_else(|_| self.clone())
+    }
+
+    /// Truncate to hour boundaries.
+    pub fn hr(&self) -> Self {
+        self.truncate("hour").unwrap_or_else(|_| self.clone())
+    }
+
+    /// Truncate to week boundaries (Sunday 00:00:00).
+    pub fn week(&self) -> Self {
+        let mut result = self.clone();
+        let len = result.len();
+        let time_unit = self.time_unit; // Hoist time_unit outside loop
+
+        for i in 0..len {
+            if !self.is_null(i) {
+                if let Some(val_i64) = self.data[i].to_i64() {
+                    if let Some(dt) = Self::i64_to_datetime(val_i64, time_unit) {
+                        // Get the current weekday (1=Sunday, 2=Monday, ..., 7=Saturday)
+                        let weekday = dt.weekday().number_from_sunday();
+                        // Calculate days to subtract to get to Sunday
+                        let days_to_sunday = (weekday - 1) as i64;
+
+                        // Subtract days and zero out time
+                        if let Some(week_start) =
+                            dt.checked_sub(time::Duration::days(days_to_sunday))
+                        {
+                            if let Some(week_start_dt) = week_start.date().with_hms(0, 0, 0).ok() {
+                                let truncated_dt = week_start_dt.assume_utc();
+                                let new_val_i64 = Self::datetime_to_i64(truncated_dt, time_unit);
+
+                                if let Some(new_val_t) = T::from_i64(new_val_i64) {
+                                    result.set(i, new_val_t);
+                                } else {
+                                    result.set_null(i);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    // Type Casting Operations
+
+    /// Cast this DatetimeArray to a different TimeUnit.
+    ///
+    /// This converts the internal representation while preserving the logical datetime values.
+    pub fn cast_time_unit(&self, new_unit: TimeUnit) -> Result<Self, MinarrowError> {
+        let mut result =
+            Self::with_capacity(self.len(), self.is_nullable(), Some(new_unit.clone()));
+
+        for i in 0..self.len() {
+            if self.is_null(i) {
+                result.push_null();
+            } else if let Some(dt) = self.value_to_datetime(i) {
+                // Convert to new unit
+                let new_val: i64 = match new_unit {
+                    TimeUnit::Seconds => dt.unix_timestamp(),
+                    TimeUnit::Milliseconds => {
+                        dt.unix_timestamp() * 1_000i64 + (dt.nanosecond() / 1_000_000) as i64
+                    }
+                    TimeUnit::Microseconds => {
+                        dt.unix_timestamp() * 1_000_000i64 + (dt.nanosecond() / 1_000) as i64
+                    }
+                    TimeUnit::Nanoseconds => {
+                        dt.unix_timestamp() * 1_000_000_000i64 + dt.nanosecond() as i64
+                    }
+                    TimeUnit::Days => dt.unix_timestamp() / 86400i64,
+                };
+
+                if let Some(new_val_t) = T::from_i64(new_val) {
+                    result.push(new_val_t);
+                } else {
+                    result.push_null();
+                }
+            } else {
+                result.push_null();
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(all(test, feature = "datetime_ops"))]
+mod tests {
+    use super::*;
+    use time::Duration;
+    use vec64::vec64;
+
+    #[test]
+    fn test_add_duration() {
+        let arr = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let result = arr.add_duration(Duration::seconds(10)).unwrap();
+
+        assert_eq!(result.value(0), Some(1010));
+        assert_eq!(result.value(1), Some(2010));
+        assert_eq!(result.value(2), Some(3010));
+    }
+
+    #[test]
+    fn test_sub_duration() {
+        let arr = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let result = arr.sub_duration(Duration::seconds(10)).unwrap();
+
+        assert_eq!(result.value(0), Some(990));
+        assert_eq!(result.value(1), Some(1990));
+        assert_eq!(result.value(2), Some(2990));
+    }
+
+    #[test]
+    fn test_add_days() {
+        let arr = DatetimeArray::<i64>::from_slice(&[0, 86400, 172800], Some(TimeUnit::Seconds));
+        let result = arr.add_days(1).unwrap();
+
+        assert_eq!(result.value(0), Some(86400));
+        assert_eq!(result.value(1), Some(172800));
+        assert_eq!(result.value(2), Some(259200));
+    }
+
+    #[test]
+    fn test_is_before() {
+        let arr1 = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500, 2500, 2500], Some(TimeUnit::Seconds));
+
+        let result = arr1.is_before(&arr2).unwrap();
+
+        assert_eq!(result.get(0), Some(true));
+        assert_eq!(result.get(1), Some(true));
+        assert_eq!(result.get(2), Some(false));
+    }
+
+    #[test]
+    fn test_is_after() {
+        let arr1 = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500, 2500, 2500], Some(TimeUnit::Seconds));
+
+        let result = arr1.is_after(&arr2).unwrap();
+
+        assert_eq!(result.get(0), Some(false));
+        assert_eq!(result.get(1), Some(false));
+        assert_eq!(result.get(2), Some(true));
+    }
+
+    #[test]
+    fn test_component_extraction() {
+        // 2023-11-14 22:13:20 UTC
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.year().get(0), Some(2023));
+        assert_eq!(arr.month().get(0), Some(11));
+        assert_eq!(arr.day().get(0), Some(14));
+        assert_eq!(arr.hour().get(0), Some(22));
+        assert_eq!(arr.minute().get(0), Some(13));
+        assert_eq!(arr.second().get(0), Some(20));
+    }
+
+    // Arithmetic Operations Tests
+
+    #[test]
+    fn test_add_months() {
+        // 2023-01-15 -> add 2 months -> 2023-03-15
+        let timestamp = 1_673_740_800i64; // 2023-01-15 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(2).unwrap();
+
+        // Verify we got March 15th, 2023
+        assert_eq!(result.year().get(0), Some(2023));
+        assert_eq!(result.month().get(0), Some(3));
+        assert_eq!(result.day().get(0), Some(15));
+    }
+
+    #[test]
+    fn test_add_months_overflow_year() {
+        // 2023-11-15 -> add 3 months -> 2024-02-15
+        let timestamp = 1_700_006_400i64; // 2023-11-15 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(3).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2024));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(15));
+    }
+
+    #[test]
+    fn test_add_months_end_of_month() {
+        // 2023-01-31 -> add 1 month -> 2023-02-28 (not 02-31)
+        let timestamp = 1_675_123_200i64; // 2023-01-31 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(1).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2023));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(28)); // Clamped to Feb 28
+    }
+
+    #[test]
+    fn test_add_years() {
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_years(2).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2025));
+        assert_eq!(result.month().get(0), Some(11));
+        assert_eq!(result.day().get(0), Some(14));
+    }
+
+    // Duration Operations Tests
+
+    #[test]
+    fn test_diff() {
+        let arr1 = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500, 2500, 2500], Some(TimeUnit::Seconds));
+
+        let result = arr1.diff(&arr2, TimeUnit::Seconds).unwrap();
+
+        assert_eq!(result.get(0), Some(-500));
+        assert_eq!(result.get(1), Some(-500));
+        assert_eq!(result.get(2), Some(500));
+    }
+
+    #[test]
+    fn test_abs_diff() {
+        let arr1 = DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000], Some(TimeUnit::Seconds));
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500, 2500, 2500], Some(TimeUnit::Seconds));
+
+        let result = arr1.abs_diff(&arr2, TimeUnit::Seconds).unwrap();
+
+        assert_eq!(result.get(0), Some(500));
+        assert_eq!(result.get(1), Some(500));
+        assert_eq!(result.get(2), Some(500));
+    }
+
+    #[test]
+    fn test_diff_different_units() {
+        let arr1 =
+            DatetimeArray::<i64>::from_slice(&[1_000_000, 2_000_000], Some(TimeUnit::Milliseconds));
+        let arr2 =
+            DatetimeArray::<i64>::from_slice(&[1_500_000, 2_500_000], Some(TimeUnit::Milliseconds));
+
+        let result = arr1.diff(&arr2, TimeUnit::Milliseconds).unwrap();
+
+        assert_eq!(result.get(0), Some(-500_000));
+        assert_eq!(result.get(1), Some(-500_000));
+    }
+
+    // Comparison Operations Tests
+
+    #[test]
+    fn test_between() {
+        let arr =
+            DatetimeArray::<i64>::from_slice(&[1000, 2000, 3000, 4000], Some(TimeUnit::Seconds));
+        let start =
+            DatetimeArray::<i64>::from_slice(&[1500, 1500, 1500, 1500], Some(TimeUnit::Seconds));
+        let end =
+            DatetimeArray::<i64>::from_slice(&[3500, 3500, 3500, 3500], Some(TimeUnit::Seconds));
+
+        let result = arr.between(&start, &end).unwrap();
+
+        assert_eq!(result.get(0), Some(false)); // 1000 < 1500
+        assert_eq!(result.get(1), Some(true)); // 1500 <= 2000 <= 3500
+        assert_eq!(result.get(2), Some(true)); // 1500 <= 3000 <= 3500
+        assert_eq!(result.get(3), Some(false)); // 4000 > 3500
+    }
+
+    // Component Extraction Tests
+
+    #[test]
+    fn test_weekday() {
+        // 2023-11-14 is a Tuesday (1=Sunday, 2=Monday, 3=Tuesday, ...)
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.weekday().get(0), Some(3)); // Tuesday = 3
+    }
+
+    #[test]
+    fn test_weekday_all_days() {
+        // Test all days of the week
+        let timestamps = vec![
+            1_699_747_200i64, // 2023-11-12 Sunday
+            1_699_833_600i64, // 2023-11-13 Monday
+            1_699_920_000i64, // 2023-11-14 Tuesday
+            1_700_006_400i64, // 2023-11-15 Wednesday
+            1_700_092_800i64, // 2023-11-16 Thursday
+            1_700_179_200i64, // 2023-11-17 Friday
+            1_700_265_600i64, // 2023-11-18 Saturday
+        ];
+        let arr = DatetimeArray::<i64>::from_slice(&timestamps, Some(TimeUnit::Seconds));
+        let weekdays = arr.weekday();
+
+        assert_eq!(weekdays.get(0), Some(1)); // Sunday
+        assert_eq!(weekdays.get(1), Some(2)); // Monday
+        assert_eq!(weekdays.get(2), Some(3)); // Tuesday
+        assert_eq!(weekdays.get(3), Some(4)); // Wednesday
+        assert_eq!(weekdays.get(4), Some(5)); // Thursday
+        assert_eq!(weekdays.get(5), Some(6)); // Friday
+        assert_eq!(weekdays.get(6), Some(7)); // Saturday
+    }
+
+    #[test]
+    fn test_day_of_year() {
+        // 2023-11-14 is the 318th day of the year
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.day_of_year().get(0), Some(318));
+    }
+
+    #[test]
+    fn test_iso_week() {
+        // 2023-11-14 is in ISO week 46
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.iso_week().get(0), Some(46));
+    }
+
+    #[test]
+    fn test_quarter() {
+        let timestamps = vec![
+            1_672_531_200i64, // 2023-01-01 -> Q1
+            1_680_307_200i64, // 2023-04-01 -> Q2
+            1_688_169_600i64, // 2023-07-01 -> Q3
+            1_696_118_400i64, // 2023-10-01 -> Q4
+        ];
+        let arr = DatetimeArray::<i64>::from_slice(&timestamps, Some(TimeUnit::Seconds));
+        let quarters = arr.quarter();
+
+        assert_eq!(quarters.get(0), Some(1));
+        assert_eq!(quarters.get(1), Some(2));
+        assert_eq!(quarters.get(2), Some(3));
+        assert_eq!(quarters.get(3), Some(4));
+    }
+
+    #[test]
+    fn test_week_of_year() {
+        // 2023-11-14 is in week 46
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let week = arr.week_of_year().get(0).unwrap();
+        assert!(week >= 45 && week <= 47); // Allow some variation in week calculation
+    }
+
+    #[test]
+    fn test_is_leap_year() {
+        let timestamps = vec![
+            1_672_531_200i64, // 2023-01-01 -> not leap
+            1_704_067_200i64, // 2024-01-01 -> leap year
+        ];
+        let arr = DatetimeArray::<i64>::from_slice(&timestamps, Some(TimeUnit::Seconds));
+        let leap_years = arr.is_leap_year();
+
+        assert_eq!(leap_years.get(0), Some(false));
+        assert_eq!(leap_years.get(1), Some(true));
+    }
+
+    // Truncation Operations Tests
+
+    #[test]
+    fn test_truncate_to_year() {
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.truncate("year").unwrap();
+
+        assert_eq!(result.year().get(0), Some(2023));
+        assert_eq!(result.month().get(0), Some(1));
+        assert_eq!(result.day().get(0), Some(1));
+        assert_eq!(result.hour().get(0), Some(0));
+        assert_eq!(result.minute().get(0), Some(0));
+        assert_eq!(result.second().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_to_month() {
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.truncate("month").unwrap();
+
+        assert_eq!(result.year().get(0), Some(2023));
+        assert_eq!(result.month().get(0), Some(11));
+        assert_eq!(result.day().get(0), Some(1));
+        assert_eq!(result.hour().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_to_day() {
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.truncate("day").unwrap();
+
+        assert_eq!(result.hour().get(0), Some(0));
+        assert_eq!(result.minute().get(0), Some(0));
+        assert_eq!(result.second().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_to_hour() {
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.truncate("hour").unwrap();
+
+        assert_eq!(result.hour().get(0), Some(22));
+        assert_eq!(result.minute().get(0), Some(0));
+        assert_eq!(result.second().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_shorthand_methods() {
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        // Test sec(), min(), hr()
+        let sec_result = arr.sec();
+        let min_result = arr.min();
+        let hr_result = arr.hr();
+
+        assert_eq!(sec_result.second().get(0), Some(20));
+        assert_eq!(min_result.minute().get(0), Some(13));
+        assert_eq!(min_result.second().get(0), Some(0));
+        assert_eq!(hr_result.hour().get(0), Some(22));
+        assert_eq!(hr_result.minute().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_week() {
+        // 2023-11-14 is a Tuesday; week should start on Sunday 2023-11-12
+        let timestamp = 1_700_000_000i64; // 2023-11-14 22:13:20 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.week();
+
+        assert_eq!(result.day().get(0), Some(12)); // Sunday
+        assert_eq!(result.hour().get(0), Some(0));
+        assert_eq!(result.minute().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_truncate_subsecond_us() {
+        let arr = DatetimeArray::<i64>::from_slice(&[1_234_567], Some(TimeUnit::Nanoseconds));
+        let result = arr.us();
+
+        // Should truncate to nearest microsecond (1000 ns)
+        assert_eq!(result.value(0), Some(1_234_000));
+    }
+
+    #[test]
+    fn test_truncate_subsecond_ms() {
+        let arr = DatetimeArray::<i64>::from_slice(&[1_234_567_890], Some(TimeUnit::Nanoseconds));
+        let result = arr.ms();
+
+        // Should truncate to nearest millisecond (1_000_000 ns)
+        assert_eq!(result.value(0), Some(1_234_000_000));
+    }
+
+    // Type Casting Tests
+
+    #[test]
+    fn test_cast_time_unit_seconds_to_milliseconds() {
+        let arr = DatetimeArray::<i64>::from_slice(&[1, 2, 3], Some(TimeUnit::Seconds));
+        let result = arr.cast_time_unit(TimeUnit::Milliseconds).unwrap();
+
+        assert_eq!(result.value(0), Some(1_000));
+        assert_eq!(result.value(1), Some(2_000));
+        assert_eq!(result.value(2), Some(3_000));
+        assert_eq!(result.time_unit, TimeUnit::Milliseconds);
+    }
+
+    #[test]
+    fn test_cast_time_unit_milliseconds_to_seconds() {
+        let arr =
+            DatetimeArray::<i64>::from_slice(&[1_000, 2_000, 3_000], Some(TimeUnit::Milliseconds));
+        let result = arr.cast_time_unit(TimeUnit::Seconds).unwrap();
+
+        assert_eq!(result.value(0), Some(1));
+        assert_eq!(result.value(1), Some(2));
+        assert_eq!(result.value(2), Some(3));
+        assert_eq!(result.time_unit, TimeUnit::Seconds);
+    }
+
+    #[test]
+    fn test_cast_time_unit_preserves_datetime() {
+        // Cast should preserve the actual datetime, just change representation
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let as_ms = arr.cast_time_unit(TimeUnit::Milliseconds).unwrap();
+        let back_to_sec = as_ms.cast_time_unit(TimeUnit::Seconds).unwrap();
+
+        assert_eq!(back_to_sec.value(0), Some(timestamp));
+    }
+
+    // Null Handling and Edge Cases
+
+    #[test]
+    fn test_operations_with_nulls() {
+        use crate::Bitmask;
+
+        let mask = Bitmask::from_bools(&[true, false, true]);
+        let arr = DatetimeArray::new(
+            vec64![1000i64, 2000, 3000],
+            Some(mask),
+            Some(TimeUnit::Seconds),
+        );
+
+        let result = arr.add_duration(Duration::seconds(10)).unwrap();
+
+        assert_eq!(result.value(0), Some(1010));
+        assert_eq!(result.value(1), None); // null preserved
+        assert_eq!(result.value(2), Some(3010));
+    }
+
+    #[test]
+    fn test_comparison_with_nulls() {
+        use crate::Bitmask;
+
+        let mask1 = Bitmask::from_bools(&[true, false, true]);
+        let arr1 = DatetimeArray::new(
+            vec64![1000i64, 2000, 3000],
+            Some(mask1),
+            Some(TimeUnit::Seconds),
+        );
+
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500, 2500, 2500], Some(TimeUnit::Seconds));
+
+        let result = arr1.is_before(&arr2).unwrap();
+
+        assert_eq!(result.get(0), Some(true));
+        assert_eq!(result.get(1), None); // null input -> null output
+        assert_eq!(result.get(2), Some(false));
+    }
+
+    #[test]
+    fn test_diff_length_mismatch() {
+        let arr1 = DatetimeArray::<i64>::from_slice(&[1000, 2000], Some(TimeUnit::Seconds));
+        let arr2 = DatetimeArray::<i64>::from_slice(&[1500], Some(TimeUnit::Seconds));
+
+        let result = arr1.diff(&arr2, TimeUnit::Seconds);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_component_extraction_with_nulls() {
+        use crate::Bitmask;
+
+        let mask = Bitmask::from_bools(&[true, false]);
+        let arr = DatetimeArray::new(
+            vec64![1_700_000_000i64, 1_700_086_400],
+            Some(mask),
+            Some(TimeUnit::Seconds),
+        );
+
+        let years = arr.year();
+        assert_eq!(years.get(0), Some(2023));
+        assert_eq!(years.get(1), None);
+    }
+
+    // Edge Case Tests
+
+    #[test]
+    fn test_leap_year_feb_29() {
+        // 2024-02-29 00:00:00 UTC (leap year)
+        let timestamp = 1_709_164_800i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.year().get(0), Some(2024));
+        assert_eq!(arr.month().get(0), Some(2));
+        assert_eq!(arr.day().get(0), Some(29));
+        assert_eq!(arr.is_leap_year().get(0), Some(true));
+    }
+
+    #[test]
+    fn test_add_months_leap_year_feb_29() {
+        // 2024-02-29 -> add 1 month -> 2024-03-29
+        let timestamp = 1_709_164_800i64; // 2024-02-29 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(1).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2024));
+        assert_eq!(result.month().get(0), Some(3));
+        assert_eq!(result.day().get(0), Some(29));
+    }
+
+    #[test]
+    fn test_add_months_leap_year_to_non_leap() {
+        // 2024-02-29 -> add 12 months -> 2025-02-28 (clamped, not leap year)
+        let timestamp = 1_709_164_800i64; // 2024-02-29 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(12).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2025));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(28)); // Clamped to Feb 28
+        assert_eq!(result.is_leap_year().get(0), Some(false));
+    }
+
+    #[test]
+    fn test_add_years_leap_year() {
+        // 2024-02-29 -> add 4 years -> 2028-02-29 (both leap years)
+        let timestamp = 1_709_164_800i64; // 2024-02-29 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_years(4).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2028));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(29));
+    }
+
+    #[test]
+    fn test_add_years_leap_to_non_leap() {
+        // 2024-02-29 -> add 1 year -> 2025-02-28 (clamped)
+        let timestamp = 1_709_164_800i64; // 2024-02-29 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_years(1).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2025));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(28)); // Clamped
+    }
+
+    #[test]
+    fn test_year_boundary_dec_31_to_jan_1() {
+        // 2023-12-31 -> add 1 day -> 2024-01-01
+        let timestamp = 1_704_067_199i64; // 2023-12-31 23:59:59 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_days(1).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2024));
+        assert_eq!(result.month().get(0), Some(1));
+        assert_eq!(result.day().get(0), Some(1));
+    }
+
+    #[test]
+    fn test_month_boundary_jan_31_to_feb_1() {
+        // 2024-01-31 -> add 1 day -> 2024-02-01
+        let timestamp = 1_706_659_200i64; // 2024-01-31 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_days(1).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2024));
+        assert_eq!(result.month().get(0), Some(2));
+        assert_eq!(result.day().get(0), Some(1));
+    }
+
+    #[test]
+    fn test_negative_months() {
+        // 2023-03-15 -> subtract 3 months -> 2022-12-15
+        let timestamp = 1_678_838_400i64; // 2023-03-15 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_months(-3).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2022));
+        assert_eq!(result.month().get(0), Some(12));
+        assert_eq!(result.day().get(0), Some(15));
+    }
+
+    #[test]
+    fn test_negative_years() {
+        // 2023-11-14 -> subtract 5 years -> 2018-11-14
+        let timestamp = 1_700_000_000i64;
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let result = arr.add_years(-5).unwrap();
+
+        assert_eq!(result.year().get(0), Some(2018));
+        assert_eq!(result.month().get(0), Some(11));
+        assert_eq!(result.day().get(0), Some(14));
+    }
+
+    #[test]
+    fn test_century_leap_year_2000() {
+        // 2000 is a leap year (divisible by 400)
+        let timestamp = 951_868_800i64; // 2000-03-01 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let prev_day = arr.add_days(-1).unwrap();
+
+        assert_eq!(prev_day.year().get(0), Some(2000));
+        assert_eq!(prev_day.month().get(0), Some(2));
+        assert_eq!(prev_day.day().get(0), Some(29)); // Feb 29 exists
+    }
+
+    #[test]
+    fn test_century_non_leap_year_1900() {
+        // 1900 was not a leap year (divisible by 100 but not 400)
+        // March 1, 1900 minus 1 day should be Feb 28, not Feb 29
+        let timestamp = -2_203_891_200i64; // 1900-03-01 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+        let prev_day = arr.add_days(-1).unwrap();
+
+        assert_eq!(prev_day.year().get(0), Some(1900));
+        assert_eq!(prev_day.month().get(0), Some(2));
+        assert_eq!(prev_day.day().get(0), Some(28)); // Feb 28, not 29
+    }
+
+    #[test]
+    fn test_extreme_timestamp_min() {
+        // Test with a very old date (year 1)
+        let timestamp = -62_135_596_800i64; // 0001-01-01 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.year().get(0), Some(1));
+        assert_eq!(arr.month().get(0), Some(1));
+        assert_eq!(arr.day().get(0), Some(1));
+    }
+
+    #[test]
+    fn test_extreme_timestamp_far_future() {
+        // Test with a far future date (year 3000)
+        let timestamp = 32_503_680_000i64; // 3000-01-01 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        assert_eq!(arr.year().get(0), Some(3000));
+        assert_eq!(arr.month().get(0), Some(1));
+        assert_eq!(arr.day().get(0), Some(1));
+    }
+
+    #[test]
+    fn test_different_time_units_precision() {
+        // Test that different time units maintain precision correctly
+        let arr_sec = DatetimeArray::<i64>::from_slice(&[1_700_000_000], Some(TimeUnit::Seconds));
+        let arr_ms = arr_sec.cast_time_unit(TimeUnit::Milliseconds).unwrap();
+        let arr_us = arr_ms.cast_time_unit(TimeUnit::Microseconds).unwrap();
+        let arr_ns = arr_us.cast_time_unit(TimeUnit::Nanoseconds).unwrap();
+
+        // Convert back to seconds
+        let back_to_sec = arr_ns.cast_time_unit(TimeUnit::Seconds).unwrap();
+
+        assert_eq!(back_to_sec.value(0), Some(1_700_000_000));
+    }
+
+    #[test]
+    fn test_week_start_on_sunday() {
+        // 2023-11-12 is Sunday, week should start on itself
+        let timestamp = 1_699_747_200i64; // 2023-11-12 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.week();
+
+        assert_eq!(result.day().get(0), Some(12)); // Same day (Sunday)
+        assert_eq!(result.hour().get(0), Some(0));
+    }
+
+    #[test]
+    fn test_week_start_on_saturday() {
+        // 2023-11-18 is Saturday, week should start on Sunday 2023-11-12
+        let timestamp = 1_700_265_600i64; // 2023-11-18 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[timestamp], Some(TimeUnit::Seconds));
+
+        let result = arr.week();
+
+        assert_eq!(result.day().get(0), Some(12)); // Previous Sunday
+    }
+
+    #[test]
+    fn test_add_months_varying_lengths() {
+        // Test adding months across months of different lengths
+        // Jan (31) -> Feb (28/29) -> Mar (31) -> Apr (30)
+        let jan_31 = 1_675_123_200i64; // 2023-01-31 00:00:00 UTC
+        let arr = DatetimeArray::<i64>::from_slice(&[jan_31], Some(TimeUnit::Seconds));
+
+        // Jan 31 + 1 month = Feb 28 (clamped)
+        let feb = arr.add_months(1).unwrap();
+        assert_eq!(feb.month().get(0), Some(2));
+        assert_eq!(feb.day().get(0), Some(28));
+
+        // Feb 28 + 1 month = Mar 28
+        let mar = feb.add_months(1).unwrap();
+        assert_eq!(mar.month().get(0), Some(3));
+        assert_eq!(mar.day().get(0), Some(28));
+    }
+}

--- a/src/structs/variants/datetime/tz.rs
+++ b/src/structs/variants/datetime/tz.rs
@@ -1,0 +1,591 @@
+//! # **Timezone Database** - *IANA Timezone Mappings*
+//!
+//! Provides compile-time static maps for looking up timezone offsets by:
+//! - IANA timezone identifier (e.g., "Australia/Sydney")
+//! - Timezone abbreviation (e.g., "AEST", "AEDT")
+//! - Direct offset string (e.g., "+10:00")
+//!
+//! All 341 canonical timezones from the IANA timezone database are included.
+//! However, these are based on static entries. If you have any specific
+//! Datetime timezone requirements, you are responsible for checking and verifying
+//! them.
+//! 
+//! If you would like to update a timezone, please file a PR or issue. 
+
+#[cfg(feature = "datetime_ops")]
+use phf::{phf_map, Map};
+
+/// Timezone information including standard and DST offsets with abbreviations
+#[cfg(feature = "datetime_ops")]
+#[derive(Debug, Clone, Copy)]
+pub struct TimezoneInfo {
+    /// Standard time offset (e.g., "+10:00")
+    pub std_offset: &'static str,
+    /// Daylight saving time offset (e.g., "+11:00")
+    pub dst_offset: &'static str,
+    /// Standard time abbreviation (e.g., "AEST")
+    pub std_abbr: &'static str,
+    /// Daylight saving time abbreviation (e.g., "AEDT")
+    pub dst_abbr: &'static str,
+}
+
+/// Static map of IANA timezone identifiers to TimezoneInfo
+#[cfg(feature = "datetime_ops")]
+pub static TZ_DATABASE: Map<&'static str, TimezoneInfo> = phf_map! {
+    // Africa
+    "Africa/Abidjan" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "Africa/Algiers" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "CET", dst_abbr: "" },
+    "Africa/Bissau" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "Africa/Cairo" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Africa/Casablanca" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "+01", dst_abbr: "+01" },
+    "Africa/Ceuta" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Africa/El_Aaiun" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "+01", dst_abbr: "+01" },
+    "Africa/Johannesburg" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "SAST", dst_abbr: "" },
+    "Africa/Juba" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "CAT", dst_abbr: "" },
+    "Africa/Khartoum" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "CAT", dst_abbr: "" },
+    "Africa/Lagos" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "WAT", dst_abbr: "" },
+    "Africa/Maputo" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "CAT", dst_abbr: "" },
+    "Africa/Monrovia" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "Africa/Nairobi" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "EAT", dst_abbr: "" },
+    "Africa/Ndjamena" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "WAT", dst_abbr: "" },
+    "Africa/Sao_Tome" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "Africa/Tripoli" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "EET", dst_abbr: "" },
+    "Africa/Tunis" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "CET", dst_abbr: "" },
+    "Africa/Windhoek" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "CAT", dst_abbr: "" },
+
+    // America
+    "America/Adak" => TimezoneInfo { std_offset: "-10:00", dst_offset: "-09:00", std_abbr: "HST", dst_abbr: "HDT" },
+    "America/Anchorage" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+    "America/Araguaina" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Buenos_Aires" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Catamarca" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Cordoba" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Jujuy" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/La_Rioja" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Mendoza" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Rio_Gallegos" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Salta" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/San_Juan" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/San_Luis" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Tucuman" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Argentina/Ushuaia" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Asuncion" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "-04" },
+    "America/Bahia" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Bahia_Banderas" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Barbados" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "AST", dst_abbr: "" },
+    "America/Belem" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Belize" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Boa_Vista" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Bogota" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "America/Boise" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Cambridge_Bay" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Campo_Grande" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Cancun" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "EST", dst_abbr: "" },
+    "America/Caracas" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Cayenne" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Chicago" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Chihuahua" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Ciudad_Juarez" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Costa_Rica" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Coyhaique" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Cuiaba" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Danmarkshavn" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "America/Dawson" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Dawson_Creek" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Denver" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Detroit" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Edmonton" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Eirunepe" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "America/El_Salvador" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Fort_Nelson" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Fortaleza" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Glace_Bay" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "America/Goose_Bay" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "America/Grand_Turk" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Guatemala" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Guayaquil" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "America/Guyana" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Halifax" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "America/Havana" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Hermosillo" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Indiana/Indianapolis" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Indiana/Knox" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Indiana/Marengo" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Indiana/Petersburg" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Indiana/Tell_City" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Indiana/Vevay" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Indiana/Vincennes" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Indiana/Winamac" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Inuvik" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-06:00", std_abbr: "MST", dst_abbr: "MDT" },
+    "America/Iqaluit" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Jamaica" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "EST", dst_abbr: "" },
+    "America/Juneau" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+    "America/Kentucky/Louisville" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Kentucky/Monticello" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/La_Paz" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Lima" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "America/Los_Angeles" => TimezoneInfo { std_offset: "-08:00", dst_offset: "-07:00", std_abbr: "PST", dst_abbr: "PDT" },
+    "America/Maceio" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Managua" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Manaus" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Martinique" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "AST", dst_abbr: "" },
+    "America/Matamoros" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Mazatlan" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Menominee" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Merida" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Metlakatla" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+    "America/Mexico_City" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Miquelon" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-02:00", std_abbr: "-03", dst_abbr: "-02" },
+    "America/Moncton" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "America/Monterrey" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Montevideo" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/New_York" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Nome" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+    "America/Noronha" => TimezoneInfo { std_offset: "-02:00", dst_offset: "-02:00", std_abbr: "-02", dst_abbr: "" },
+    "America/North_Dakota/Beulah" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/North_Dakota/Center" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/North_Dakota/New_Salem" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Nuuk" => TimezoneInfo { std_offset: "-02:00", dst_offset: "-02:00", std_abbr: "-02", dst_abbr: "-02" },
+    "America/Ojinaga" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Panama" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "EST", dst_abbr: "" },
+    "America/Paramaribo" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Phoenix" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Port-au-Prince" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Porto_Velho" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "America/Puerto_Rico" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "AST", dst_abbr: "" },
+    "America/Punta_Arenas" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Rankin_Inlet" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Recife" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Regina" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Resolute" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Rio_Branco" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "America/Santarem" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Santiago" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "-04", dst_abbr: "-03" },
+    "America/Santo_Domingo" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "AST", dst_abbr: "" },
+    "America/Sao_Paulo" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "America/Scoresbysund" => TimezoneInfo { std_offset: "-02:00", dst_offset: "-01:00", std_abbr: "-02", dst_abbr: "-01" },
+    "America/Sitka" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+    "America/St_Johns" => TimezoneInfo { std_offset: "-03:30", dst_offset: "-02:30", std_abbr: "NST", dst_abbr: "NDT" },
+    "America/Swift_Current" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Tegucigalpa" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "CST", dst_abbr: "" },
+    "America/Thule" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "America/Tijuana" => TimezoneInfo { std_offset: "-08:00", dst_offset: "-07:00", std_abbr: "PST", dst_abbr: "PDT" },
+    "America/Toronto" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-04:00", std_abbr: "EST", dst_abbr: "EDT" },
+    "America/Vancouver" => TimezoneInfo { std_offset: "-08:00", dst_offset: "-07:00", std_abbr: "PST", dst_abbr: "PDT" },
+    "America/Whitehorse" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "MST", dst_abbr: "" },
+    "America/Winnipeg" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "CST", dst_abbr: "CDT" },
+    "America/Yakutat" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-08:00", std_abbr: "AKST", dst_abbr: "AKDT" },
+
+    // Antarctica
+    "Antarctica/Casey" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Antarctica/Davis" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Antarctica/Macquarie" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "AEST", dst_abbr: "AEST" },
+    "Antarctica/Mawson" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Antarctica/Palmer" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "Antarctica/Rothera" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "Antarctica/Troll" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+02:00", std_abbr: "+00", dst_abbr: "+02" },
+    "Antarctica/Vostok" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+
+    // Asia
+    "Asia/Almaty" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Amman" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Asia/Anadyr" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Asia/Aqtau" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Aqtobe" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Ashgabat" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Atyrau" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Baghdad" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Asia/Baku" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Asia/Bangkok" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Barnaul" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Beirut" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Asia/Bishkek" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Asia/Chita" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Asia/Colombo" => TimezoneInfo { std_offset: "+05:30", dst_offset: "+05:30", std_abbr: "IST", dst_abbr: "" },
+    "Asia/Damascus" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Asia/Dhaka" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Asia/Dili" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Asia/Dubai" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Asia/Dushanbe" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Famagusta" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Asia/Gaza" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Asia/Hebron" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Asia/Ho_Chi_Minh" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Hong_Kong" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "HKT", dst_abbr: "" },
+    "Asia/Hovd" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Irkutsk" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Asia/Jakarta" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "WIB", dst_abbr: "" },
+    "Asia/Jayapura" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "WIT", dst_abbr: "" },
+    "Asia/Jerusalem" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "IST", dst_abbr: "IDT" },
+    "Asia/Kabul" => TimezoneInfo { std_offset: "+04:30", dst_offset: "+04:30", std_abbr: "+0430", dst_abbr: "" },
+    "Asia/Kamchatka" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Asia/Karachi" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "PKT", dst_abbr: "" },
+    "Asia/Kathmandu" => TimezoneInfo { std_offset: "+05:45", dst_offset: "+05:45", std_abbr: "NPT", dst_abbr: "" },
+    "Asia/Khandyga" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Asia/Kolkata" => TimezoneInfo { std_offset: "+05:30", dst_offset: "+05:30", std_abbr: "IST", dst_abbr: "" },
+    "Asia/Krasnoyarsk" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Kuching" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Asia/Macau" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "CST", dst_abbr: "" },
+    "Asia/Magadan" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Asia/Makassar" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "WITA", dst_abbr: "" },
+    "Asia/Manila" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "PST", dst_abbr: "" },
+    "Asia/Nicosia" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Asia/Novokuznetsk" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Novosibirsk" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Omsk" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Asia/Oral" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Pontianak" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "WIB", dst_abbr: "" },
+    "Asia/Pyongyang" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "KST", dst_abbr: "" },
+    "Asia/Qatar" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Asia/Qostanay" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Qyzylorda" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Riyadh" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Asia/Sakhalin" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Asia/Samarkand" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Seoul" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "KST", dst_abbr: "" },
+    "Asia/Shanghai" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "CST", dst_abbr: "" },
+    "Asia/Singapore" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Asia/Srednekolymsk" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Asia/Taipei" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "CST", dst_abbr: "" },
+    "Asia/Tashkent" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Tbilisi" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Asia/Tehran" => TimezoneInfo { std_offset: "+03:30", dst_offset: "+03:30", std_abbr: "+0330", dst_abbr: "" },
+    "Asia/Thimphu" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Asia/Tokyo" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "JST", dst_abbr: "" },
+    "Asia/Tomsk" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Asia/Ulaanbaatar" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Asia/Urumqi" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Asia/Ust-Nera" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "+10", dst_abbr: "" },
+    "Asia/Vladivostok" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "+10", dst_abbr: "" },
+    "Asia/Yakutsk" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Asia/Yangon" => TimezoneInfo { std_offset: "+06:30", dst_offset: "+06:30", std_abbr: "MMT", dst_abbr: "" },
+    "Asia/Yekaterinburg" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Asia/Yerevan" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+
+    // Atlantic
+    "Atlantic/Azores" => TimezoneInfo { std_offset: "-01:00", dst_offset: "+00:00", std_abbr: "-01", dst_abbr: "+00" },
+    "Atlantic/Bermuda" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-03:00", std_abbr: "AST", dst_abbr: "ADT" },
+    "Atlantic/Canary" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "WET", dst_abbr: "WEST" },
+    "Atlantic/Cape_Verde" => TimezoneInfo { std_offset: "-01:00", dst_offset: "-01:00", std_abbr: "-01", dst_abbr: "" },
+    "Atlantic/Faroe" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "WET", dst_abbr: "WEST" },
+    "Atlantic/Madeira" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "WET", dst_abbr: "WEST" },
+    "Atlantic/South_Georgia" => TimezoneInfo { std_offset: "-02:00", dst_offset: "-02:00", std_abbr: "-02", dst_abbr: "" },
+    "Atlantic/Stanley" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+
+    // Australia
+    "Australia/Adelaide" => TimezoneInfo { std_offset: "+09:30", dst_offset: "+10:30", std_abbr: "ACST", dst_abbr: "ACDT" },
+    "Australia/Brisbane" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "AEST", dst_abbr: "" },
+    "Australia/Broken_Hill" => TimezoneInfo { std_offset: "+09:30", dst_offset: "+10:30", std_abbr: "ACST", dst_abbr: "ACDT" },
+    "Australia/Darwin" => TimezoneInfo { std_offset: "+09:30", dst_offset: "+09:30", std_abbr: "ACST", dst_abbr: "" },
+    "Australia/Eucla" => TimezoneInfo { std_offset: "+08:45", dst_offset: "+08:45", std_abbr: "+0845", dst_abbr: "" },
+    "Australia/Hobart" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+11:00", std_abbr: "AEST", dst_abbr: "AEDT" },
+    "Australia/Lindeman" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "AEST", dst_abbr: "" },
+    "Australia/Lord_Howe" => TimezoneInfo { std_offset: "+10:30", dst_offset: "+11:00", std_abbr: "+1030", dst_abbr: "+11" },
+    "Australia/Melbourne" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+11:00", std_abbr: "AEST", dst_abbr: "AEDT" },
+    "Australia/Perth" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "AWST", dst_abbr: "" },
+    "Australia/Sydney" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+11:00", std_abbr: "AEST", dst_abbr: "AEDT" },
+
+    // Etc
+    "Etc/GMT" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "GMT", dst_abbr: "" },
+    "Etc/GMT+1" => TimezoneInfo { std_offset: "-01:00", dst_offset: "-01:00", std_abbr: "-01", dst_abbr: "" },
+    "Etc/GMT+10" => TimezoneInfo { std_offset: "-10:00", dst_offset: "-10:00", std_abbr: "-10", dst_abbr: "" },
+    "Etc/GMT+11" => TimezoneInfo { std_offset: "-11:00", dst_offset: "-11:00", std_abbr: "-11", dst_abbr: "" },
+    "Etc/GMT+12" => TimezoneInfo { std_offset: "-12:00", dst_offset: "-12:00", std_abbr: "-12", dst_abbr: "" },
+    "Etc/GMT+2" => TimezoneInfo { std_offset: "-02:00", dst_offset: "-02:00", std_abbr: "-02", dst_abbr: "" },
+    "Etc/GMT+3" => TimezoneInfo { std_offset: "-03:00", dst_offset: "-03:00", std_abbr: "-03", dst_abbr: "" },
+    "Etc/GMT+4" => TimezoneInfo { std_offset: "-04:00", dst_offset: "-04:00", std_abbr: "-04", dst_abbr: "" },
+    "Etc/GMT+5" => TimezoneInfo { std_offset: "-05:00", dst_offset: "-05:00", std_abbr: "-05", dst_abbr: "" },
+    "Etc/GMT+6" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "-06", dst_abbr: "" },
+    "Etc/GMT+7" => TimezoneInfo { std_offset: "-07:00", dst_offset: "-07:00", std_abbr: "-07", dst_abbr: "" },
+    "Etc/GMT+8" => TimezoneInfo { std_offset: "-08:00", dst_offset: "-08:00", std_abbr: "-08", dst_abbr: "" },
+    "Etc/GMT+9" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-09:00", std_abbr: "-09", dst_abbr: "" },
+    "Etc/GMT-1" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+01:00", std_abbr: "+01", dst_abbr: "" },
+    "Etc/GMT-10" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "+10", dst_abbr: "" },
+    "Etc/GMT-11" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Etc/GMT-12" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Etc/GMT-13" => TimezoneInfo { std_offset: "+13:00", dst_offset: "+13:00", std_abbr: "+13", dst_abbr: "" },
+    "Etc/GMT-14" => TimezoneInfo { std_offset: "+14:00", dst_offset: "+14:00", std_abbr: "+14", dst_abbr: "" },
+    "Etc/GMT-2" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "+02", dst_abbr: "" },
+    "Etc/GMT-3" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Etc/GMT-4" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Etc/GMT-5" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Etc/GMT-6" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Etc/GMT-7" => TimezoneInfo { std_offset: "+07:00", dst_offset: "+07:00", std_abbr: "+07", dst_abbr: "" },
+    "Etc/GMT-8" => TimezoneInfo { std_offset: "+08:00", dst_offset: "+08:00", std_abbr: "+08", dst_abbr: "" },
+    "Etc/GMT-9" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Etc/UTC" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "UTC", dst_abbr: "" },
+
+    // Europe
+    "Europe/Andorra" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Astrakhan" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Europe/Athens" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Belgrade" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Berlin" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Brussels" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Bucharest" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Budapest" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Chisinau" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Dublin" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "GMT", dst_abbr: "IST" },
+    "Europe/Gibraltar" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Helsinki" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Istanbul" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Europe/Kaliningrad" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+02:00", std_abbr: "EET", dst_abbr: "" },
+    "Europe/Kirov" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "MSK", dst_abbr: "" },
+    "Europe/Kyiv" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Lisbon" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "WET", dst_abbr: "WEST" },
+    "Europe/London" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+01:00", std_abbr: "GMT", dst_abbr: "BST" },
+    "Europe/Madrid" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Malta" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Minsk" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "+03", dst_abbr: "" },
+    "Europe/Moscow" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "MSK", dst_abbr: "" },
+    "Europe/Paris" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Prague" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Riga" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Rome" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Samara" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Europe/Saratov" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Europe/Simferopol" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "MSK", dst_abbr: "" },
+    "Europe/Sofia" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Tallinn" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Tirane" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Ulyanovsk" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+    "Europe/Vienna" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Vilnius" => TimezoneInfo { std_offset: "+02:00", dst_offset: "+03:00", std_abbr: "EET", dst_abbr: "EEST" },
+    "Europe/Volgograd" => TimezoneInfo { std_offset: "+03:00", dst_offset: "+03:00", std_abbr: "MSK", dst_abbr: "" },
+    "Europe/Warsaw" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+    "Europe/Zurich" => TimezoneInfo { std_offset: "+01:00", dst_offset: "+02:00", std_abbr: "CET", dst_abbr: "CEST" },
+
+    // Factory
+    "Factory" => TimezoneInfo { std_offset: "+00:00", dst_offset: "+00:00", std_abbr: "+00", dst_abbr: "" },
+
+    // Indian
+    "Indian/Chagos" => TimezoneInfo { std_offset: "+06:00", dst_offset: "+06:00", std_abbr: "+06", dst_abbr: "" },
+    "Indian/Maldives" => TimezoneInfo { std_offset: "+05:00", dst_offset: "+05:00", std_abbr: "+05", dst_abbr: "" },
+    "Indian/Mauritius" => TimezoneInfo { std_offset: "+04:00", dst_offset: "+04:00", std_abbr: "+04", dst_abbr: "" },
+
+    // Pacific
+    "Pacific/Apia" => TimezoneInfo { std_offset: "+13:00", dst_offset: "+13:00", std_abbr: "+13", dst_abbr: "" },
+    "Pacific/Auckland" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+13:00", std_abbr: "NZST", dst_abbr: "NZDT" },
+    "Pacific/Bougainville" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Pacific/Chatham" => TimezoneInfo { std_offset: "+12:45", dst_offset: "+13:45", std_abbr: "+1245", dst_abbr: "+1345" },
+    "Pacific/Easter" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-05:00", std_abbr: "-06", dst_abbr: "-05" },
+    "Pacific/Efate" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Pacific/Fakaofo" => TimezoneInfo { std_offset: "+13:00", dst_offset: "+13:00", std_abbr: "+13", dst_abbr: "" },
+    "Pacific/Fiji" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Pacific/Galapagos" => TimezoneInfo { std_offset: "-06:00", dst_offset: "-06:00", std_abbr: "-06", dst_abbr: "" },
+    "Pacific/Gambier" => TimezoneInfo { std_offset: "-09:00", dst_offset: "-09:00", std_abbr: "-09", dst_abbr: "" },
+    "Pacific/Guadalcanal" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Pacific/Guam" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "ChST", dst_abbr: "" },
+    "Pacific/Honolulu" => TimezoneInfo { std_offset: "-10:00", dst_offset: "-10:00", std_abbr: "HST", dst_abbr: "" },
+    "Pacific/Kanton" => TimezoneInfo { std_offset: "+13:00", dst_offset: "+13:00", std_abbr: "+13", dst_abbr: "" },
+    "Pacific/Kiritimati" => TimezoneInfo { std_offset: "+14:00", dst_offset: "+14:00", std_abbr: "+14", dst_abbr: "" },
+    "Pacific/Kosrae" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Pacific/Kwajalein" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Pacific/Marquesas" => TimezoneInfo { std_offset: "-09:30", dst_offset: "-09:30", std_abbr: "-0930", dst_abbr: "" },
+    "Pacific/Nauru" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Pacific/Niue" => TimezoneInfo { std_offset: "-11:00", dst_offset: "-11:00", std_abbr: "-11", dst_abbr: "" },
+    "Pacific/Norfolk" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "+11" },
+    "Pacific/Noumea" => TimezoneInfo { std_offset: "+11:00", dst_offset: "+11:00", std_abbr: "+11", dst_abbr: "" },
+    "Pacific/Pago_Pago" => TimezoneInfo { std_offset: "-11:00", dst_offset: "-11:00", std_abbr: "SST", dst_abbr: "" },
+    "Pacific/Palau" => TimezoneInfo { std_offset: "+09:00", dst_offset: "+09:00", std_abbr: "+09", dst_abbr: "" },
+    "Pacific/Pitcairn" => TimezoneInfo { std_offset: "-08:00", dst_offset: "-08:00", std_abbr: "-08", dst_abbr: "" },
+    "Pacific/Port_Moresby" => TimezoneInfo { std_offset: "+10:00", dst_offset: "+10:00", std_abbr: "+10", dst_abbr: "" },
+    "Pacific/Rarotonga" => TimezoneInfo { std_offset: "-10:00", dst_offset: "-10:00", std_abbr: "-10", dst_abbr: "" },
+    "Pacific/Tahiti" => TimezoneInfo { std_offset: "-10:00", dst_offset: "-10:00", std_abbr: "-10", dst_abbr: "" },
+    "Pacific/Tarawa" => TimezoneInfo { std_offset: "+12:00", dst_offset: "+12:00", std_abbr: "+12", dst_abbr: "" },
+    "Pacific/Tongatapu" => TimezoneInfo { std_offset: "+13:00", dst_offset: "+13:00", std_abbr: "+13", dst_abbr: "" },
+};
+
+/// Static map of timezone abbreviations to standard offset strings
+///
+/// Note: Some abbreviations are ambiguous (e.g., "CST" can mean Central Standard Time,
+/// China Standard Time, or Cuba Standard Time). This map uses the most common interpretation.
+/// For unambiguous results, use IANA timezone identifiers or direct offset strings.
+#[cfg(feature = "datetime_ops")]
+pub static ABBR_TO_OFFSET: Map<&'static str, &'static str> = phf_map! {
+    // Common Standard Time Zones
+    "GMT" => "+00:00",
+    "UTC" => "+00:00",
+    "WET" => "+00:00",
+    "WEST" => "+01:00",
+    "CET" => "+01:00",
+    "CEST" => "+02:00",
+    "EET" => "+02:00",
+    "EEST" => "+03:00",
+    "MSK" => "+03:00",
+
+    // Africa
+    "WAT" => "+01:00",   // West Africa Time
+    "CAT" => "+02:00",   // Central Africa Time
+    "EAT" => "+03:00",   // East Africa Time
+    "SAST" => "+02:00",  // South Africa Standard Time
+
+    // Americas
+    "NST" => "-03:30",   // Newfoundland Standard Time
+    "NDT" => "-02:30",   // Newfoundland Daylight Time
+    "AST" => "-04:00",   // Atlantic Standard Time
+    "ADT" => "-03:00",   // Atlantic Daylight Time
+    "EST" => "-05:00",   // Eastern Standard Time (North America)
+    "EDT" => "-04:00",   // Eastern Daylight Time
+    "CST" => "-06:00",   // Central Standard Time (North America, most common)
+    "CDT" => "-05:00",   // Central Daylight Time
+    "MST" => "-07:00",   // Mountain Standard Time
+    "MDT" => "-06:00",   // Mountain Daylight Time
+    "PST" => "-08:00",   // Pacific Standard Time (North America, most common)
+    "PDT" => "-07:00",   // Pacific Daylight Time
+    "AKST" => "-09:00",  // Alaska Standard Time
+    "AKDT" => "-08:00",  // Alaska Daylight Time
+    "HST" => "-10:00",   // Hawaii Standard Time
+    "HDT" => "-09:00",   // Hawaii Daylight Time
+    "SST" => "-11:00",   // Samoa Standard Time
+
+    // Asia
+    "IST" => "+05:30",   // India Standard Time (most common)
+    "IDT" => "+03:00",   // Israel Daylight Time
+    "PKT" => "+05:00",   // Pakistan Standard Time
+    "WIB" => "+07:00",   // Western Indonesian Time
+    "WITA" => "+08:00",  // Central Indonesian Time
+    "WIT" => "+09:00",   // Eastern Indonesian Time
+    "HKT" => "+08:00",   // Hong Kong Time
+    "JST" => "+09:00",   // Japan Standard Time
+    "KST" => "+09:00",   // Korea Standard Time
+
+    // Australia/Pacific
+    "AWST" => "+08:00",  // Australian Western Standard Time
+    "ACST" => "+09:30",  // Australian Central Standard Time
+    "ACDT" => "+10:30",  // Australian Central Daylight Time
+    "AEST" => "+10:00",  // Australian Eastern Standard Time
+    "AEDT" => "+11:00",  // Australian Eastern Daylight Time
+    "NZST" => "+12:00",  // New Zealand Standard Time
+    "NZDT" => "+13:00",  // New Zealand Daylight Time
+    "ChST" => "+10:00",  // Chamorro Standard Time
+
+    // Europe
+    "BST" => "+01:00",   // British Summer Time
+};
+
+/// Looks up timezone information by IANA identifier, abbreviation, or direct offset
+///
+/// # Arguments
+/// * `tz_str` - Timezone string (e.g., "Australia/Sydney", "AEST", "+10:00")
+///
+/// # Returns
+/// Standard offset string in ±HH:MM format, or None if not found
+///
+/// # Examples
+/// ```
+/// use minarrow::structs::variants::datetime::tz::lookup_timezone;
+///
+/// # #[cfg(feature = "datetime_ops")]
+/// # {
+/// assert_eq!(lookup_timezone("Australia/Sydney"), Some("+10:00"));
+/// assert_eq!(lookup_timezone("AEST"), Some("+10:00"));
+/// assert_eq!(lookup_timezone("+10:00"), Some("+10:00"));
+/// assert_eq!(lookup_timezone("UTC"), Some("+00:00"));
+/// # }
+/// ```
+#[cfg(feature = "datetime_ops")]
+pub fn lookup_timezone(tz_str: &str) -> Option<&str> {
+    // Try IANA timezone identifier lookup
+    if let Some(tz_info) = TZ_DATABASE.get(tz_str) {
+        return Some(tz_info.std_offset);
+    }
+
+    // Try abbreviation lookup
+    if let Some(offset) = ABBR_TO_OFFSET.get(tz_str) {
+        return Some(offset);
+    }
+
+    // Check if it's already a direct offset string
+    if is_offset_string(tz_str) {
+        return Some(tz_str);
+    }
+
+    None
+}
+
+/// Checks if a string is a valid offset string (e.g., "+10:00", "-05:00")
+#[cfg(feature = "datetime_ops")]
+fn is_offset_string(s: &str) -> bool {
+    if s.eq_ignore_ascii_case("UTC") || s.eq_ignore_ascii_case("Z") {
+        return true;
+    }
+
+    let s = s.trim();
+    if !s.starts_with('+') && !s.starts_with('-') {
+        return false;
+    }
+
+    // Check for HH:MM format or HHMM format
+    let rest = &s[1..];
+    if rest.contains(':') {
+        // HH:MM format
+        rest.len() == 5 && rest.chars().all(|c| c.is_ascii_digit() || c == ':')
+    } else {
+        // HHMM format
+        rest.len() == 4 && rest.chars().all(|c| c.is_ascii_digit())
+    }
+}
+
+#[cfg(all(feature = "datetime", feature = "datetime_ops"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lookup_iana_identifier() {
+        assert_eq!(lookup_timezone("Australia/Sydney"), Some("+10:00"));
+        assert_eq!(lookup_timezone("America/New_York"), Some("-05:00"));
+        assert_eq!(lookup_timezone("Europe/London"), Some("+00:00"));
+        assert_eq!(lookup_timezone("Asia/Tokyo"), Some("+09:00"));
+        assert_eq!(lookup_timezone("Pacific/Auckland"), Some("+12:00"));
+    }
+
+    #[test]
+    fn test_lookup_abbreviation() {
+        assert_eq!(lookup_timezone("AEST"), Some("+10:00"));
+        assert_eq!(lookup_timezone("EST"), Some("-05:00"));
+        assert_eq!(lookup_timezone("GMT"), Some("+00:00"));
+        assert_eq!(lookup_timezone("UTC"), Some("+00:00"));
+        assert_eq!(lookup_timezone("PST"), Some("-08:00"));
+        assert_eq!(lookup_timezone("JST"), Some("+09:00"));
+    }
+
+    #[test]
+    fn test_lookup_direct_offset() {
+        assert_eq!(lookup_timezone("+10:00"), Some("+10:00"));
+        assert_eq!(lookup_timezone("-05:00"), Some("-05:00"));
+        assert_eq!(lookup_timezone("+00:00"), Some("+00:00"));
+        assert_eq!(lookup_timezone("+05:30"), Some("+05:30"));
+        assert_eq!(lookup_timezone("-03:30"), Some("-03:30"));
+    }
+
+    #[test]
+    fn test_lookup_invalid() {
+        assert_eq!(lookup_timezone("Invalid/Timezone"), None);
+        assert_eq!(lookup_timezone("INVALID"), None);
+        assert_eq!(lookup_timezone("25:00"), None);
+    }
+
+    #[test]
+    fn test_unusual_offsets() {
+        // Test unusual offset timezones
+        assert_eq!(lookup_timezone("Australia/Eucla"), Some("+08:45"));
+        assert_eq!(lookup_timezone("Asia/Kathmandu"), Some("+05:45"));
+        assert_eq!(lookup_timezone("Asia/Colombo"), Some("+05:30"));
+        assert_eq!(lookup_timezone("America/St_Johns"), Some("-03:30"));
+        assert_eq!(lookup_timezone("Pacific/Chatham"), Some("+12:45"));
+    }
+
+    #[test]
+    fn test_all_timezones_have_valid_offsets() {
+        for (tz_name, tz_info) in &TZ_DATABASE {
+            assert!(is_offset_string(tz_info.std_offset),
+                "Invalid std_offset for {}: {}", tz_name, tz_info.std_offset);
+            if !tz_info.dst_offset.is_empty() {
+                assert!(is_offset_string(tz_info.dst_offset),
+                    "Invalid dst_offset for {}: {}", tz_name, tz_info.dst_offset);
+            }
+        }
+    }
+}

--- a/src/structs/variants/integer.rs
+++ b/src/structs/variants/integer.rs
@@ -1,6 +1,6 @@
 //! # **IntegerArray Module**- *Mid-Level, Inner Typed Integer Array*
 //!
-//! Arrow-compatible, SIMD-aligned integer array optimized for analytical workloads.
+//! Arrow-compatible, SIMD-aligned integer array optimised for analytical workloads.
 //!
 //! ## Overview
 //! - Logical type: fixed-width signed/unsigned integers (`T: Integer`).

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -373,16 +373,10 @@ impl Display for ArrayV {
             self.len, self.offset, nulls
         )?;
 
-        // Take a view into the head_len elements
-        let display_view = Self {
-            array: self.array.clone(), // arc clone
-            offset: self.offset,
-            len: head_len,
-            null_count: OnceLock::new(), // Create new lock for this view
-        };
+        // Delegate to the inner array's Display by formatting a slice of it
+        let sliced_array = self.array.slice_clone(self.offset, head_len);
 
-        // Delegate to the inner array's Display
-        for line in format!("{display_view}").lines() {
+        for line in format!("{}", sliced_array).lines() {
             writeln!(f, "  {line}")?;
         }
 

--- a/src/structs/views/bitmask_view.rs
+++ b/src/structs/views/bitmask_view.rs
@@ -193,7 +193,7 @@ impl BitmaskV {
 
     /// Returns the underlying window as a tuple: (&Bitmask, offset, len).
     #[inline]
-    pub fn as_tuple(&self) -> BitmaskVT {
+    pub fn as_tuple(&self) -> BitmaskVT<'_> {
         (&self.bitmask, self.offset, self.len)
     }
 }

--- a/src/structs/views/chunked/super_array_view.rs
+++ b/src/structs/views/chunked/super_array_view.rs
@@ -147,7 +147,7 @@ impl SuperArrayV {
     ///
     /// Allows walking across potentially chunked memory logically row-by-row.
     #[inline]
-    pub fn iter_rows(&self) -> impl Iterator<Item = ArrayVT> + '_ {
+    pub fn iter_rows(&self) -> impl Iterator<Item = ArrayVT<'_>> + '_ {
         self.slices
             .iter()
             .flat_map(|slice| {

--- a/src/structs/views/table_view.rs
+++ b/src/structs/views/table_view.rs
@@ -25,8 +25,8 @@
 //! # use minarrow::{Table, TableV, Array, IntegerArray, FieldArray};
 //! # use std::sync::Arc;
 //! // Build a simple 2-column table
-//! let a = FieldArray::from_inner("a", Array::from_int32(IntegerArray::<i32>::from_slice(&[1,2,3,4,5])));
-//! let b = FieldArray::from_inner("b", Array::from_int32(IntegerArray::<i32>::from_slice(&[10,20,30,40,50])));
+//! let a = FieldArray::from_arr("a", Array::from_int32(IntegerArray::<i32>::from_slice(&[1,2,3,4,5])));
+//! let b = FieldArray::from_arr("b", Array::from_int32(IntegerArray::<i32>::from_slice(&[10,20,30,40,50])));
 //! let mut tbl = Table::new("T".to_string(), vec![a,b].into());
 //!
 //! // View rows 1..4 (3 rows total)

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -120,7 +120,7 @@ fn test_array_to_arrow_datetime_infer_date64_and_ts_ns() {
     )));
     let f_tsns = Field::new(
         "ts_ns",
-        ArrowType::Timestamp(TimeUnit::Nanoseconds),
+        ArrowType::Timestamp(TimeUnit::Nanoseconds, None),
         false,
         None,
     );


### PR DESCRIPTION
Minarrow Release: v0.4 - Datetime Upgrade

1. Breaking Change: Replace (unreliable) `chrono` with modern `time` package
2. Add standard datetime integration and ops. 

This release levels up datetime functionality to standard.