### PR TITLE
Fix/preserve field metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.2"
+version = "0.7.4"
 dependencies = [
  "ahash",
  "arrow",

--- a/pyo3/Cargo.lock
+++ b/pyo3/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.1"
+version = "0.7.4"
 dependencies = [
  "libc",
  "num-traits",

--- a/src/enums/value/impls.rs
+++ b/src/enums/value/impls.rs
@@ -514,7 +514,8 @@ impl Consolidate for Vec<Value> {
                 let mut iter = self.into_iter();
                 let first = iter.next().unwrap();
                 iter.fold(first, |acc, val| {
-                    acc.concat(val).expect("consolidate: all Values must be the same variant")
+                    acc.concat(val)
+                        .expect("consolidate: all Values must be the same variant")
                 })
             }
         }
@@ -533,11 +534,9 @@ impl IntoIterator for Value {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Value::VecValue(items) => {
-                Arc::try_unwrap(items)
-                    .unwrap_or_else(|arc| (*arc).clone())
-                    .into_iter()
-            }
+            Value::VecValue(items) => Arc::try_unwrap(items)
+                .unwrap_or_else(|arc| (*arc).clone())
+                .into_iter(),
             other => vec![other].into_iter(),
         }
     }

--- a/src/kernels/broadcast/super_array.rs
+++ b/src/kernels/broadcast/super_array.rs
@@ -275,8 +275,10 @@ pub fn broadcast_arrayview_to_superarray(
 
         match result {
             Value::Array(arr) => {
-                let field_array =
-                    FieldArray::new_arc(super_array.field.clone().unwrap(), Arc::unwrap_or_clone(arr));
+                let field_array = FieldArray::new_arc(
+                    super_array.field.clone().unwrap(),
+                    Arc::unwrap_or_clone(arr),
+                );
                 result_chunks.push(field_array);
             }
             _ => {
@@ -329,8 +331,10 @@ pub fn broadcast_superarray_to_arrayview(
 
         match result {
             Value::Array(arr) => {
-                let field_array =
-                    FieldArray::new_arc(super_array.field.clone().unwrap(), Arc::unwrap_or_clone(arr));
+                let field_array = FieldArray::new_arc(
+                    super_array.field.clone().unwrap(),
+                    Arc::unwrap_or_clone(arr),
+                );
                 result_chunks.push(field_array);
             }
             _ => {

--- a/src/kernels/broadcast/table.rs
+++ b/src/kernels/broadcast/table.rs
@@ -659,17 +659,13 @@ mod tests {
         assert_eq!(result.chunks().len(), 2);
 
         // Both chunks: [2,3,4] + [10,20,30] = [12,23,34] and [2,3,4] + [40,50,60] = [42,53,64]
-        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) =
-            &result.chunks()[0]
-        {
+        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) = &result.chunks()[0] {
             assert_eq!(arr.data.as_slice(), &[12, 23, 34]);
         } else {
             panic!("Expected Int32 array");
         }
 
-        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) =
-            &result.chunks()[1]
-        {
+        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) = &result.chunks()[1] {
             assert_eq!(arr.data.as_slice(), &[42, 53, 64]);
         } else {
             panic!("Expected Int32 array");

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -881,7 +881,6 @@ impl Default for SuperArray {
     }
 }
 
-
 // Vec<Array> -> SuperArray
 //
 // Multiple chunks without field metadata

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -26,7 +26,6 @@ use polars::prelude::Column;
 use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator};
 
 use super::field_array::FieldArray;
-use crate::traits::consolidate::Consolidate;
 #[cfg(all(feature = "views", feature = "select"))]
 use crate::ArrayV;
 use crate::Field;
@@ -35,6 +34,7 @@ use crate::SuperTable;
 #[cfg(feature = "views")]
 use crate::TableV;
 use crate::enums::{error::MinarrowError, shape_dim::ShapeDim};
+use crate::traits::consolidate::Consolidate;
 #[cfg(all(feature = "views", feature = "select"))]
 use crate::traits::selection::{ColumnSelection, DataSelector, FieldSelector, RowSelection};
 use crate::traits::{


### PR DESCRIPTION
Preserve field-level metadata during FFI import

      Fix two issues that caused field metadata to be silently dropped:

      1. Import side: Added field_from_c_schema() utility that
         decodes metadata from ArrowSchema and standardised extraction
         logic in import_from_c_owned, import_record_batch_stream_with_metadata,
         and import_array_stream.

      2. Export side: fixed field metadata in accordance with the Arrow C Data Interface binary spec.
      Switched both export sites and rb_stream_get_schema to use encode_arrow_metadata().