### PR TITLE
Consolidate multi-batch streams in record_batch_to_rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.2"
+version = "0.7.4"
 dependencies = [
  "ahash",
  "arrow",

--- a/pyo3/Cargo.lock
+++ b/pyo3/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.1"
+version = "0.7.4"
 dependencies = [
  "libc",
  "num-traits",


### PR DESCRIPTION
Record_batch_to_rust silently dropped all batches after the first when a PyCapsule stream yielded multiple batches, causing silent data loss.

Instead now, builds a Table per batch and consolidate via Vec<Table>.consolidate(), which handles single-batch with no overhead and multi-batch via column-wise concatenation. The concatenation has allocation cost however this is avoided by using table_to_rust which returns SuperArray.