### PR TITLE
Add get_raw to MaskedArray and feature-gate Index<usize> behind unche…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.2"
+version = "0.7.4"
 dependencies = [
  "ahash",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,16 @@ broadcast = []
 # Adds byte size trait for best-effort size calculation
 size = []
 
+# Enables `arr[i]` indexing on MaskedArray types via Index<usize>.
+#
+# Without this feature, use `.get(i)` for null-safe access returning Option<T>,
+# or `.get_raw(i)` for direct buffer access bypassing null checks.
+#
+# The Index trait does not check null masks, so enabling this on nullable arrays
+# will silently return raw buffer values for null elements. Enable if you
+# understand the implications and prefer the ergonomic `[]` syntax.
+unchecked_index = []
+
 # Adds pandas-style selection for Table and TableV with .c() and .r() methods
 select = []
 

--- a/pyo3/Cargo.lock
+++ b/pyo3/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "minarrow"
-version = "0.7.1"
+version = "0.7.4"
 dependencies = [
  "libc",
  "num-traits",

--- a/src/enums/value/impls.rs
+++ b/src/enums/value/impls.rs
@@ -514,7 +514,8 @@ impl Consolidate for Vec<Value> {
                 let mut iter = self.into_iter();
                 let first = iter.next().unwrap();
                 iter.fold(first, |acc, val| {
-                    acc.concat(val).expect("consolidate: all Values must be the same variant")
+                    acc.concat(val)
+                        .expect("consolidate: all Values must be the same variant")
                 })
             }
         }
@@ -533,11 +534,9 @@ impl IntoIterator for Value {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Value::VecValue(items) => {
-                Arc::try_unwrap(items)
-                    .unwrap_or_else(|arc| (*arc).clone())
-                    .into_iter()
-            }
+            Value::VecValue(items) => Arc::try_unwrap(items)
+                .unwrap_or_else(|arc| (*arc).clone())
+                .into_iter(),
             other => vec![other].into_iter(),
         }
     }

--- a/src/kernels/broadcast/super_array.rs
+++ b/src/kernels/broadcast/super_array.rs
@@ -275,8 +275,10 @@ pub fn broadcast_arrayview_to_superarray(
 
         match result {
             Value::Array(arr) => {
-                let field_array =
-                    FieldArray::new_arc(super_array.field.clone().unwrap(), Arc::unwrap_or_clone(arr));
+                let field_array = FieldArray::new_arc(
+                    super_array.field.clone().unwrap(),
+                    Arc::unwrap_or_clone(arr),
+                );
                 result_chunks.push(field_array);
             }
             _ => {
@@ -329,8 +331,10 @@ pub fn broadcast_superarray_to_arrayview(
 
         match result {
             Value::Array(arr) => {
-                let field_array =
-                    FieldArray::new_arc(super_array.field.clone().unwrap(), Arc::unwrap_or_clone(arr));
+                let field_array = FieldArray::new_arc(
+                    super_array.field.clone().unwrap(),
+                    Arc::unwrap_or_clone(arr),
+                );
                 result_chunks.push(field_array);
             }
             _ => {

--- a/src/kernels/broadcast/table.rs
+++ b/src/kernels/broadcast/table.rs
@@ -659,17 +659,13 @@ mod tests {
         assert_eq!(result.chunks().len(), 2);
 
         // Both chunks: [2,3,4] + [10,20,30] = [12,23,34] and [2,3,4] + [40,50,60] = [42,53,64]
-        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) =
-            &result.chunks()[0]
-        {
+        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) = &result.chunks()[0] {
             assert_eq!(arr.data.as_slice(), &[12, 23, 34]);
         } else {
             panic!("Expected Int32 array");
         }
 
-        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) =
-            &result.chunks()[1]
-        {
+        if let crate::Array::NumericArray(crate::NumericArray::Int32(arr)) = &result.chunks()[1] {
             assert_eq!(arr.data.as_slice(), &[42, 53, 64]);
         } else {
             panic!("Expected Int32 array");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -249,6 +249,11 @@ macro_rules! impl_masked_array {
                 if self.is_null(idx) { None } else { self.data().get(idx).copied() }
             }
 
+            #[inline]
+            fn get_raw(&self, idx: usize) -> T {
+                self.data[idx]
+            }
+
             /// Like `get`, but skips the `idx >= len()` check.
                     #[inline(always)]
             unsafe fn get_unchecked(&self, idx: usize) -> Option<T> {
@@ -626,10 +631,24 @@ macro_rules! impl_masked_array {
                 })
             }
         }
+
+        /// Single-index returns a reference to the value at position `i`.
+        ///
+        /// Requires the `unchecked_index` feature. This does not check the null mask,
+        /// so null elements return raw buffer values. Use `.get(i)` for null-safe
+        /// access or `.get_raw(i)` for explicit raw buffer access.
+        #[cfg(feature = "unchecked_index")]
+        impl<T: $bound> ::std::ops::Index<usize> for $array<T> {
+            type Output = T;
+            #[inline]
+            fn index(&self, i: usize) -> &T {
+                &self.data[i]
+            }
+        }
     };
 }
 
-/// Implement `from_vec` + `from_std_vec` for the “numeric-shaped” arrays
+/// Implement `from_vec` + `from_std_vec` for the "numeric-shaped" arrays
 /// (IntegerArray / FloatArray / DatetimeArray).
 #[macro_export]
 macro_rules! impl_from_vec_primitive {
@@ -880,6 +899,9 @@ macro_rules! impl_arc_masked_array {
             fn get(&self, idx: usize) -> Option<Self::CopyType> {
                 (**self).get(idx)
             }
+            fn get_raw(&self, idx: usize) -> Self::CopyType {
+                (**self).get_raw(idx)
+            }
             fn set(&mut self, idx: usize, value: Self::LogicalType) {
                 ::std::sync::Arc::make_mut(self).set(idx, value)
             }
@@ -1000,6 +1022,9 @@ macro_rules! impl_arc_masked_array {
             }
             fn get(&self, idx: usize) -> Option<Self::CopyType> {
                 (**self).get(idx)
+            }
+            fn get_raw(&self, idx: usize) -> Self::CopyType {
+                (**self).get_raw(idx)
             }
             fn set(&mut self, idx: usize, value: Self::LogicalType) {
                 ::std::sync::Arc::make_mut(self).set(idx, value)

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -881,7 +881,6 @@ impl Default for SuperArray {
     }
 }
 
-
 // Vec<Array> -> SuperArray
 //
 // Multiple chunks without field metadata

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -26,7 +26,6 @@ use polars::prelude::Column;
 use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator};
 
 use super::field_array::FieldArray;
-use crate::traits::consolidate::Consolidate;
 #[cfg(all(feature = "views", feature = "select"))]
 use crate::ArrayV;
 use crate::Field;
@@ -35,6 +34,7 @@ use crate::SuperTable;
 #[cfg(feature = "views")]
 use crate::TableV;
 use crate::enums::{error::MinarrowError, shape_dim::ShapeDim};
+use crate::traits::consolidate::Consolidate;
 #[cfg(all(feature = "views", feature = "select"))]
 use crate::traits::selection::{ColumnSelection, DataSelector, FieldSelector, RowSelection};
 use crate::traits::{

--- a/src/structs/variants/boolean.rs
+++ b/src/structs/variants/boolean.rs
@@ -283,12 +283,16 @@ impl DerefMut for BooleanArray<()> {
     }
 }
 
-/// Single‐index -> logical bit
+/// Single-index returns the logical bit value.
+///
+/// Requires the `unchecked_index` feature. This does not check the null mask,
+/// so null elements return raw buffer values. Use `.get(i)` for null-safe
+/// access or `.get_raw(i)` for explicit raw buffer access.
+#[cfg(feature = "unchecked_index")]
 impl Index<usize> for BooleanArray<()> {
     type Output = bool;
     #[inline]
     fn index(&self, i: usize) -> &bool {
-        // Return a reference to a static `true`/`false`
         if self.data.get(i) { &true } else { &false }
     }
 }
@@ -365,6 +369,11 @@ impl MaskedArray for BooleanArray<()> {
         } else {
             Some(self.data.get(idx))
         }
+    }
+
+    #[inline]
+    fn get_raw(&self, idx: usize) -> bool {
+        self.data.get(idx)
     }
 
     /// Sets the value at `idx`. Marks as valid.
@@ -1418,5 +1427,25 @@ mod tests_parallel {
         assert!(null_mask.get(3));
         assert!(!null_mask.get(4)); // Last entry is null
         assert_eq!(arr1.null_count(), 1);
+    }
+
+    #[test]
+    fn test_get_raw_returns_buffer_value_regardless_of_null() {
+        let mut arr = BooleanArray::from_slice(&[true, false, true]);
+        arr.push_null();
+        assert_eq!(arr.get(3), None);
+        // get_raw bypasses null mask and returns the raw buffer value
+        let raw = arr.get_raw(3);
+        assert_eq!(raw, bool::default());
+    }
+
+    #[cfg(feature = "unchecked_index")]
+    #[test]
+    fn test_index_bypasses_null_mask() {
+        let mut arr = BooleanArray::from_slice(&[true, false, true]);
+        arr.set_null(1);
+        assert_eq!(arr.get(1), None);
+        // Index bypasses the null mask and returns the raw buffer value
+        assert_eq!(arr[1], false);
     }
 }

--- a/src/structs/variants/datetime/mod.rs
+++ b/src/structs/variants/datetime/mod.rs
@@ -836,6 +836,32 @@ mod tests {
             crate::enums::error::MinarrowError::IncompatibleTypeError { .. }
         ));
     }
+
+    #[test]
+    fn test_get_raw_returns_buffer_value_regardless_of_null() {
+        let mut arr = DatetimeArray::<i64>::from_slice(
+            &[100, 200, 300],
+            Some(crate::enums::time_units::TimeUnit::Milliseconds),
+        );
+        arr.push_null();
+        assert_eq!(arr.get(3), None);
+        // get_raw bypasses null mask and returns the raw buffer value
+        let raw = arr.get_raw(3);
+        assert_eq!(raw, i64::default());
+    }
+
+    #[cfg(feature = "unchecked_index")]
+    #[test]
+    fn test_index_bypasses_null_mask() {
+        let mut arr = DatetimeArray::<i64>::from_slice(
+            &[100, 200, 300],
+            Some(crate::enums::time_units::TimeUnit::Milliseconds),
+        );
+        arr.set_null(1);
+        assert_eq!(arr.get(1), None);
+        // Index bypasses the null mask and returns the raw buffer value
+        assert_eq!(arr[1], 200);
+    }
 }
 
 #[cfg(test)]

--- a/src/structs/variants/float.rs
+++ b/src/structs/variants/float.rs
@@ -400,6 +400,25 @@ mod tests {
         assert_eq!(result.get(4), None);
         assert_eq!(result.null_count(), 2);
     }
+
+    #[test]
+    fn test_get_raw_returns_buffer_value_regardless_of_null() {
+        let mut arr = FloatArray::<f64>::from_slice(&[1.1, 2.2, 3.3]);
+        arr.push_null();
+        assert_eq!(arr.get(3), None);
+        let raw = arr.get_raw(3);
+        assert_eq!(raw, f64::default());
+    }
+
+    #[cfg(feature = "unchecked_index")]
+    #[test]
+    fn test_index_bypasses_null_mask() {
+        let mut arr = FloatArray::<f64>::from_slice(&[1.1, 2.2, 3.3]);
+        arr.set_null(1);
+        assert_eq!(arr.get(1), None);
+        // Index bypasses the null mask and returns the raw buffer value
+        assert_eq!(arr[1], 2.2);
+    }
 }
 
 #[cfg(test)]

--- a/src/structs/variants/integer.rs
+++ b/src/structs/variants/integer.rs
@@ -565,4 +565,24 @@ mod concat_tests {
         assert_eq!(result.get(3), Some(40));
         assert_eq!(result.null_count(), 2);
     }
+
+    #[test]
+    fn test_get_raw_returns_buffer_value_regardless_of_null() {
+        let mut arr = IntegerArray::<i32>::from_slice(&[10, 20, 30]);
+        arr.push_null();
+        assert_eq!(arr.get(3), None);
+        // get_raw bypasses null mask and returns the raw buffer value
+        let raw = arr.get_raw(3);
+        assert_eq!(raw, i32::default());
+    }
+
+    #[cfg(feature = "unchecked_index")]
+    #[test]
+    fn test_index_bypasses_null_mask() {
+        let mut arr = IntegerArray::<i32>::from_slice(&[10, 20, 30]);
+        arr.set_null(1);
+        assert_eq!(arr.get(1), None);
+        // Index bypasses the null mask and returns the raw buffer value
+        assert_eq!(arr[1], 20);
+    }
 }

--- a/src/traits/masked_array.rs
+++ b/src/traits/masked_array.rs
@@ -61,6 +61,15 @@ pub trait MaskedArray {
     /// Retrieves the value at the given index, or None if null or beyond length.
     fn get(&self, idx: usize) -> Option<Self::CopyType>;
 
+    /// Returns the raw buffer value at `idx` without checking the null mask.
+    ///
+    /// Use this when you intentionally need the underlying buffer value
+    /// regardless of null status, e.g. in performance-critical loops
+    /// where you handle nulls separately via the bitmask.
+    ///
+    /// For null-safe access, use `.get(i)` which returns `Option<T>`.
+    fn get_raw(&self, idx: usize) -> Self::CopyType;
+
     /// Sets the value at the given index, updating the null‐mask.
     fn set(&mut self, idx: usize, value: Self::LogicalType);
 


### PR DESCRIPTION
…cked_index

The arr[i] Index<usize> impls on BooleanArray and StringArray silently bypassed null masks, returning raw buffer values for null elements.

Rather than panicking, Index<usize> is now gated behind the unchecked_index feature flag so users must opt in. Without the feature, arr[i] does not compile, directing users to .get(i) for null-safe Option<T> access or the new .get_raw(i) for raw buffer access.