### PR TITLE
Add from_apache_arrow / from_polars bridges and try_* fallible siblings

### DIFF
--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -28,9 +28,7 @@ use std::any::TypeId;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-#[cfg(feature = "cast_arrow")]
-use crate::ffi::arrow_c_ffi::export_to_c;
-#[cfg(feature = "cast_arrow")]
+#[cfg(any(feature = "cast_arrow", feature = "cast_polars"))]
 use crate::ffi::schema::Schema;
 #[cfg(feature = "cast_arrow")]
 use arrow::array::ArrayRef;
@@ -2911,57 +2909,64 @@ impl Array {
         }
     }
 
-    /// Derive a `Field` from the array (via `Field::from_array`)
-    /// and call `to_apache_arrow_with_field`.
+    // ===========================================================
+    // Apache Arrow bridge - tested under tests/apache_arrow.rs
+    // ===========================================================
+    //
+    // For specific logical types such as Timestamp/Time/Duration/Interval,
+    // wrap the array in a `FieldArray` with the desired `Field` and
+    // call `FieldArray::to_apache_arrow()`.
+
+    /// Build an arrow-rs `ArrayRef`, deriving a `Field` from the array shape.
     ///
-    /// For Timestamp/Time/Duration/Interval, prefer passing
-    /// an explicit `Field` via `to_apache_arrow_with_field`.
+    /// Panics on FFI failure. For a fallible variant returning
+    /// `Result<_, MinarrowError>`, see [`Array::try_to_apache_arrow`].
+    ///
+    /// For Timestamp/Time/Duration/Interval, wrap in a `FieldArray` with the
+    /// desired `Field` and use `FieldArray::to_apache_arrow()`.
     #[cfg(feature = "cast_arrow")]
     #[inline]
     pub fn to_apache_arrow(&self, name: &str) -> ArrayRef {
-        let derived = Field::from_array(name, self, None);
-        self.to_apache_arrow_with_field(&derived)
+        self.try_to_apache_arrow(name)
+            .expect("Array::to_apache_arrow failed")
     }
 
-    /// Export this Minarrow array via Arrow C FFI using `field` as the
-    /// logical type; then import into arrow-rs as `ArrayRef`.
-    ///
-    /// Use this when you need explicit temporal/interval semantics.
+    /// Fallible variant of [`Array::to_apache_arrow`].
     #[cfg(feature = "cast_arrow")]
-    #[inline]
-    pub fn to_apache_arrow_with_field(&self, field: &Field) -> ArrayRef {
-        // 1) Export using the provided logical field (source of truth)
-        let schema = Schema::from(vec![field.clone()]);
-        let (c_arr, c_schema) = export_to_c(Arc::new(self.clone()), schema);
-
-        // 2) Move FFI structs out (arrow-rs takes ownership)
-        let arr_ptr = c_arr as *mut arrow::array::ffi::FFI_ArrowArray;
-        let sch_ptr = c_schema as *mut arrow::array::ffi::FFI_ArrowSchema;
-        let ffi_arr = unsafe { arr_ptr.read() };
-        let ffi_sch = unsafe { sch_ptr.read() };
-
-        // 3) Import into arrow-rs (fully qualified)
-        let array_data = unsafe {
-            arrow::array::ffi::from_ffi(ffi_arr, &ffi_sch).expect("arrow-rs FFI import failed")
-        };
-
-        arrow::array::make_array(array_data)
+    pub fn try_to_apache_arrow(&self, name: &str) -> Result<ArrayRef, MinarrowError> {
+        let field = Field::from_array(name, self, None);
+        crate::ffi::arrow_rs::export(Arc::new(self.clone()), Schema::from(vec![field]))
     }
 
-    // ** The below 2 polars functions are tested under tests/polars.rs **
+    // ===========================================================
+    // Polars bridge - tested under tests/polars.rs
+    // ===========================================================
+    //
+    // For specific logical types, wrap in a `FieldArray` with the desired
+    // `Field` and call `FieldArray::to_polars()`.
 
-    /// Build a Polars Series using a derived Field (dtype/nullability from the array).
+    /// Build a Polars Series, deriving a `Field` from the array shape.
     ///
-    /// If you need an explicit logical type, use `to_polars_with_field`.
-    /// For **Timestamp/Time/Duration/Interval**:
-    ///     - prefer `to_polars_with_field` with an explicit Field::new.
-    ///     - then, append the`minarrow::ArrowType` to the `Field` that matches the desired datetime type.
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Array::try_to_polars`].
+    ///
+    /// For Timestamp/Time/Duration/Interval, wrap in a `FieldArray` with the
+    /// desired `Field` and use `FieldArray::to_polars()`.
     #[cfg(feature = "cast_polars")]
     pub fn to_polars(&self, name: &str) -> polars::prelude::Series {
+        self.try_to_polars(name)
+            .expect("Array::to_polars failed")
+    }
+
+    /// Fallible variant of [`Array::to_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_to_polars(&self, name: &str) -> Result<polars::prelude::Series, MinarrowError> {
+        // Map physical Datetime variants to a sensible Arrow logical type for
+        // export; specific Timestamp/Time/Duration/Interval semantics need a
+        // FieldArray with an explicit Field.
         #[cfg(feature = "datetime")]
         use crate::{TemporalArray, TimeUnit, ffi::arrow_dtype::ArrowType};
 
-        // We infer what is directly inferrable and expected
         let field = match self {
             #[cfg(feature = "datetime")]
             Array::TemporalArray(TemporalArray::Datetime32(a)) => {
@@ -2980,7 +2985,6 @@ impl Array {
                     TimeUnit::Seconds => ArrowType::Timestamp(TimeUnit::Seconds, None),
                     TimeUnit::Microseconds => ArrowType::Timestamp(TimeUnit::Microseconds, None),
                     TimeUnit::Nanoseconds => ArrowType::Timestamp(TimeUnit::Nanoseconds, None),
-                    // We default to Date64 here for compatibility rather than Date32
                     TimeUnit::Days => ArrowType::Date64,
                 };
                 Field::new(name.to_string(), ty, a.is_nullable(), None)
@@ -2988,197 +2992,56 @@ impl Array {
             _ => Field::from_array(name.to_string(), self, None),
         };
 
-        self.to_polars_with_field(name, &field)
+        crate::ffi::polars::export(
+            Arc::new(self.clone()),
+            name,
+            Schema::from(vec![field]),
+        )
+    }
+    // ===========================================================
+    // Apache Arrow / Polars import (`from_*`)
+    // ===========================================================
+
+    /// Import an arrow-rs `ArrayRef` into a Minarrow `Array`.
+    ///
+    /// The recovered `Field` (dtype + nullable + metadata) is dropped. Use
+    /// [`crate::FieldArray::from_apache_arrow`] to preserve it.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Array::try_from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn from_apache_arrow(arr: &arrow::array::ArrayRef) -> Array {
+        Self::try_from_apache_arrow(arr).expect("Array::from_apache_arrow failed")
     }
 
-    /// Export via Arrow C -> import into polars_arrow -> build Series.
-    /// Field supplies logical type; `name` is used for the Series.
+    /// Fallible variant of [`Array::from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_from_apache_arrow(
+        arr: &arrow::array::ArrayRef,
+    ) -> Result<Array, MinarrowError> {
+        let (array_arc, _field) = crate::ffi::arrow_rs::import(arr)?;
+        Ok(Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone()))
+    }
+
+    /// Import a Polars `Series` into a Minarrow `Array`.
     ///
-    /// For **Timestamp/Time/Duration/Interval**: append `minarrow::ArrowType` to the `Field`
-    /// that matches the desired datetime type.
+    /// The series name and recovered Field metadata are dropped. Use
+    /// [`crate::FieldArray::from_polars`] to preserve them.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Array::try_from_polars`].
     #[cfg(feature = "cast_polars")]
-    pub fn to_polars_with_field(&self, name: &str, field: &Field) -> polars::prelude::Series {
-        use std::sync::Arc;
+    #[inline]
+    pub fn from_polars(s: &polars::prelude::Series) -> Array {
+        Self::try_from_polars(s).expect("Array::from_polars failed")
+    }
 
-        // 1) Export  Minarrow array with the provided logical Field
-        let schema = crate::ffi::schema::Schema::from(vec![field.clone()]);
-        let (c_arr, c_schema) =
-            crate::ffi::arrow_c_ffi::export_to_c(Arc::new(self.clone()), schema);
-
-        // 2) Move ArrowArray (ownership transfer to arrow2)
-        let arr_ptr = c_arr as *mut polars_arrow::ffi::ArrowArray;
-        let _sch_ptr = c_schema as *mut polars_arrow::ffi::ArrowSchema;
-        let arr_val = unsafe { std::ptr::read(arr_ptr) };
-
-        // 3) Build arrow2 dtype directly from Field
-        // We do it this way to avoid (at the time of writing) unsupported FFI types like Nanoseconds.
-        let a2_dtype: polars_arrow::datatypes::ArrowDataType = match &field.dtype {
-            crate::ffi::arrow_dtype::ArrowType::Null => {
-                polars_arrow::datatypes::ArrowDataType::Null
-            }
-            crate::ffi::arrow_dtype::ArrowType::Boolean => {
-                polars_arrow::datatypes::ArrowDataType::Boolean
-            }
-
-            #[cfg(feature = "extended_numeric_types")]
-            crate::ffi::arrow_dtype::ArrowType::Int8 => {
-                polars_arrow::datatypes::ArrowDataType::Int8
-            }
-            #[cfg(feature = "extended_numeric_types")]
-            crate::ffi::arrow_dtype::ArrowType::Int16 => {
-                polars_arrow::datatypes::ArrowDataType::Int16
-            }
-            crate::ffi::arrow_dtype::ArrowType::Int32 => {
-                polars_arrow::datatypes::ArrowDataType::Int32
-            }
-            crate::ffi::arrow_dtype::ArrowType::Int64 => {
-                polars_arrow::datatypes::ArrowDataType::Int64
-            }
-
-            #[cfg(feature = "extended_numeric_types")]
-            crate::ffi::arrow_dtype::ArrowType::UInt8 => {
-                polars_arrow::datatypes::ArrowDataType::UInt8
-            }
-            #[cfg(feature = "extended_numeric_types")]
-            crate::ffi::arrow_dtype::ArrowType::UInt16 => {
-                polars_arrow::datatypes::ArrowDataType::UInt16
-            }
-            crate::ffi::arrow_dtype::ArrowType::UInt32 => {
-                polars_arrow::datatypes::ArrowDataType::UInt32
-            }
-            crate::ffi::arrow_dtype::ArrowType::UInt64 => {
-                polars_arrow::datatypes::ArrowDataType::UInt64
-            }
-
-            crate::ffi::arrow_dtype::ArrowType::Float32 => {
-                polars_arrow::datatypes::ArrowDataType::Float32
-            }
-            crate::ffi::arrow_dtype::ArrowType::Float64 => {
-                polars_arrow::datatypes::ArrowDataType::Float64
-            }
-
-            crate::ffi::arrow_dtype::ArrowType::String => {
-                polars_arrow::datatypes::ArrowDataType::Utf8
-            }
-            #[cfg(feature = "large_string")]
-            crate::ffi::arrow_dtype::ArrowType::LargeString => {
-                polars_arrow::datatypes::ArrowDataType::LargeUtf8
-            }
-            // Utf8View is converted to regular Utf8 during import, so map to Utf8
-            crate::ffi::arrow_dtype::ArrowType::Utf8View => {
-                polars_arrow::datatypes::ArrowDataType::Utf8
-            }
-
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Date32 => {
-                polars_arrow::datatypes::ArrowDataType::Date32
-            }
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Date64 => {
-                polars_arrow::datatypes::ArrowDataType::Date64
-            }
-
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Time32(u) => {
-                polars_arrow::datatypes::ArrowDataType::Time32(match u {
-                    crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
-                    crate::TimeUnit::Milliseconds => polars_arrow::datatypes::TimeUnit::Millisecond,
-                    _ => panic!("Time32 supports Seconds or Milliseconds only"),
-                })
-            }
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Time64(u) => {
-                polars_arrow::datatypes::ArrowDataType::Time64(match u {
-                    crate::TimeUnit::Microseconds => polars_arrow::datatypes::TimeUnit::Microsecond,
-                    crate::TimeUnit::Nanoseconds => polars_arrow::datatypes::TimeUnit::Nanosecond,
-                    _ => panic!("Time64 supports Microseconds or Nanoseconds only"),
-                })
-            }
-
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Duration32(u) => {
-                polars_arrow::datatypes::ArrowDataType::Duration(match u {
-                    crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
-                    crate::TimeUnit::Milliseconds => polars_arrow::datatypes::TimeUnit::Millisecond,
-                    _ => panic!("Duration32 supports Seconds or Milliseconds only"),
-                })
-            }
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Duration64(u) => {
-                polars_arrow::datatypes::ArrowDataType::Duration(match u {
-                    crate::TimeUnit::Microseconds => polars_arrow::datatypes::TimeUnit::Microsecond,
-                    crate::TimeUnit::Nanoseconds => polars_arrow::datatypes::TimeUnit::Nanosecond,
-                    _ => panic!("Duration64 supports Microseconds or Nanoseconds only"),
-                })
-            }
-
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Timestamp(u, tz) => {
-                polars_arrow::datatypes::ArrowDataType::Timestamp(
-                    match u {
-                        crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
-                        crate::TimeUnit::Milliseconds => {
-                            polars_arrow::datatypes::TimeUnit::Millisecond
-                        }
-                        crate::TimeUnit::Microseconds => {
-                            polars_arrow::datatypes::TimeUnit::Microsecond
-                        }
-                        crate::TimeUnit::Nanoseconds => {
-                            polars_arrow::datatypes::TimeUnit::Nanosecond
-                        }
-                        crate::TimeUnit::Days => panic!("Timestamp(Days) is invalid"),
-                    },
-                    tz.as_ref().map(|s| s.as_str().into()),
-                )
-            }
-
-            #[cfg(feature = "datetime")]
-            crate::ffi::arrow_dtype::ArrowType::Interval(iu) => {
-                polars_arrow::datatypes::ArrowDataType::Interval(match iu {
-                    crate::IntervalUnit::YearMonth => {
-                        polars_arrow::datatypes::IntervalUnit::YearMonth
-                    }
-                    crate::IntervalUnit::DaysTime => polars_arrow::datatypes::IntervalUnit::DayTime,
-                    crate::IntervalUnit::MonthDaysNs => {
-                        polars_arrow::datatypes::IntervalUnit::MonthDayNano
-                    }
-                })
-            }
-
-            crate::ffi::arrow_dtype::ArrowType::Dictionary(idx) => {
-                let key: polars_arrow::datatypes::IntegerType = match idx {
-                    #[cfg(feature = "default_categorical_8")]
-                    crate::ffi::arrow_dtype::CategoricalIndexType::UInt8 => {
-                        polars_arrow::datatypes::IntegerType::UInt8
-                    }
-                    #[cfg(feature = "extended_categorical")]
-                    crate::ffi::arrow_dtype::CategoricalIndexType::UInt16 => {
-                        polars_arrow::datatypes::IntegerType::UInt16
-                    }
-                    #[cfg(any(not(feature = "default_categorical_8"), feature = "extended_categorical"))]
-                    crate::ffi::arrow_dtype::CategoricalIndexType::UInt32 => {
-                        polars_arrow::datatypes::IntegerType::UInt32
-                    }
-                    #[cfg(feature = "extended_categorical")]
-                    crate::ffi::arrow_dtype::CategoricalIndexType::UInt64 => {
-                        polars_arrow::datatypes::IntegerType::UInt64
-                    }
-                };
-                polars_arrow::datatypes::ArrowDataType::Dictionary(
-                    key,
-                    Box::new(polars_arrow::datatypes::ArrowDataType::Utf8),
-                    false,
-                )
-            }
-        };
-
-        // 4) Import into arrow2 and build a Polars Series
-        let a2_array: Box<dyn polars_arrow::array::Array> =
-            unsafe { polars_arrow::ffi::import_array_from_c(arr_val, a2_dtype.clone()) }
-                .expect("polars_arrow import_array_from_c failed");
-
-        polars::prelude::Series::from_arrow(name.into(), a2_array)
-            .expect("Polars Series::from_arrow failed")
+    /// Fallible variant of [`Array::from_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_from_polars(s: &polars::prelude::Series) -> Result<Array, MinarrowError> {
+        let (array_arc, _field) = crate::ffi::polars::import(s)?;
+        Ok(Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone()))
     }
 }
 

--- a/src/enums/error.rs
+++ b/src/enums/error.rs
@@ -27,7 +27,7 @@
 use std::error::Error;
 use std::fmt;
 
-/// Catch all error type for `Minarrow`
+/// Catch all error types for `Minarrow`
 #[derive(Debug, PartialEq)]
 pub enum MinarrowError {
     ColumnLengthMismatch {
@@ -64,6 +64,14 @@ pub enum MinarrowError {
         feature: String,
     },
     IndexError(String),
+    /// External bridge failure surfaced by `to_apache_arrow` / `to_polars` /
+    /// `from_apache_arrow` / `from_polars` or any of their `try_*` siblings.
+    /// `source` identifies the foreign library (e.g. `"arrow-rs"`, `"polars"`)
+    /// so the same variant can carry errors from either bridge.
+    BridgeError {
+        source: &'static str,
+        message: String,
+    },
 }
 
 impl fmt::Display for MinarrowError {
@@ -143,11 +151,34 @@ impl fmt::Display for MinarrowError {
             MinarrowError::IndexError(message) => {
                 write!(f, "Index error: {}", message)
             }
+            MinarrowError::BridgeError { source, message } => {
+                write!(f, "Bridge error ({}): {}", source, message)
+            }
         }
     }
 }
 
 impl Error for MinarrowError {}
+
+#[cfg(feature = "cast_arrow")]
+impl From<arrow::error::ArrowError> for MinarrowError {
+    fn from(e: arrow::error::ArrowError) -> Self {
+        MinarrowError::BridgeError {
+            source: "arrow-rs",
+            message: e.to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "cast_polars")]
+impl From<polars::error::PolarsError> for MinarrowError {
+    fn from(e: polars::error::PolarsError) -> Self {
+        MinarrowError::BridgeError {
+            source: "polars",
+            message: e.to_string(),
+        }
+    }
+}
 
 /// Error type for all kernel operations.
 ///

--- a/src/ffi/arrow_rs.rs
+++ b/src/ffi/arrow_rs.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # **arrow-rs Bridge** - *Adapter between Minarrow's C Data Interface and the `arrow` crate*
+//!
+//! Thin reinterpret layer over [`crate::ffi::arrow_c_ffi::export_to_c`] and
+//! [`crate::ffi::arrow_c_ffi::import_from_c_owned`]. Both libraries follow the
+//! Apache Arrow C Data Interface spec, so the C structs are layout-compatible
+//! and the conversion is just a pointer cast plus a hand-off.
+//!
+//! Used by `Array::to_apache_arrow`, `FieldArray::to_apache_arrow`,
+//! `Table::to_apache_arrow` and their `from_*` siblings (and the `Super*`
+//! chunked equivalents).
+//!
+//! Gated by the `cast_arrow` feature.
+
+use std::sync::Arc;
+
+use arrow::array::ArrayRef;
+
+use crate::Field;
+use crate::enums::error::MinarrowError;
+use crate::ffi::arrow_c_ffi::{ArrowArray, ArrowSchema, export_to_c, import_from_c_owned};
+use crate::ffi::schema::Schema;
+use crate::Array;
+
+/// Export a Minarrow array to an arrow-rs `ArrayRef`.
+///
+/// `schema.fields[0]` supplies the logical type for the export (preserves
+/// Timestamp/Time/Duration/Interval semantics).
+pub fn export(array: Arc<Array>, schema: Schema) -> Result<ArrayRef, MinarrowError> {
+    let (c_arr, c_schema) = export_to_c(array, schema);
+
+    // Reinterpret as arrow-rs's layout-identical FFI structs, move contents
+    // out (arrow-rs takes ownership of the release callback), then free the
+    // now-empty heap wrappers allocated by `export_to_c`. The data Holder
+    // lives at `private_data` which moved into arrow-rs's copy, so release
+    // still fires when arrow-rs drops its copy.
+    let arr_ptr = c_arr as *mut arrow::array::ffi::FFI_ArrowArray;
+    let sch_ptr = c_schema as *mut arrow::array::ffi::FFI_ArrowSchema;
+    let ffi_arr = unsafe { arr_ptr.read() };
+    let ffi_sch = unsafe { sch_ptr.read() };
+    unsafe {
+        drop(Box::from_raw(c_arr));
+        drop(Box::from_raw(c_schema));
+    }
+
+    let array_data = unsafe { arrow::array::ffi::from_ffi(ffi_arr, &ffi_sch) }?;
+    Ok(arrow::array::make_array(array_data))
+}
+
+/// Import an arrow-rs `ArrayRef` into a Minarrow `(Arc<Array>, Field)`.
+///
+/// arrow-rs `ArrayRef` does not carry a column name; the returned `Field`
+/// has an empty `name` slot. Callers wanting a name should assign one.
+pub fn import(arr: &ArrayRef) -> Result<(Arc<Array>, Field), MinarrowError> {
+    let array_data = arr.to_data();
+    let (ffi_arr, ffi_sch) = arrow::array::ffi::to_ffi(&array_data)?;
+
+    // arrow-rs's FFI structs are layout-identical to minarrow's; transfer
+    // ownership via a Box pointer cast so `import_from_c_owned` can take
+    // it zero-copy.
+    let arr_ptr = Box::into_raw(Box::new(ffi_arr)) as *mut ArrowArray;
+    let sch_ptr = Box::into_raw(Box::new(ffi_sch)) as *mut ArrowSchema;
+    let arr_box = unsafe { Box::from_raw(arr_ptr) };
+    let sch_box = unsafe { Box::from_raw(sch_ptr) };
+
+    let (array, field) = unsafe { import_from_c_owned(arr_box, sch_box) };
+    Ok((array, field))
+}

--- a/src/ffi/polars.rs
+++ b/src/ffi/polars.rs
@@ -1,0 +1,266 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # **Polars Bridge** - *Adapter between Minarrow's C Data Interface and `polars` / `polars_arrow`*
+//!
+//! Thin reinterpret layer over [`crate::ffi::arrow_c_ffi::export_to_c`] and
+//! [`crate::ffi::arrow_c_ffi::import_from_c_owned`]. polars_arrow's FFI structs
+//! are layout-compatible with Minarrow's C ABI structs, so the export side is
+//! a pointer cast plus a hand-off to `polars_arrow::ffi::import_array_from_c`,
+//! and the import side is the symmetric step.
+//!
+//! `arrow_type_to_polars_dtype` exists because polars_arrow's
+//! `import_array_from_c` needs the dtype as a separate argument rather than
+//! decoding it from the schema's format string. We map our `ArrowType` enum
+//! directly to avoid round-tripping through any unsupported FFI types.
+//!
+//! Used by `Array::to_polars`, `FieldArray::to_polars`, `Table::to_polars`
+//! and their `from_*` siblings (and the `Super*` chunked equivalents).
+//!
+//! Gated by the `cast_polars` feature.
+
+use std::sync::Arc;
+
+use polars::prelude::{CompatLevel, Series};
+
+use crate::enums::error::MinarrowError;
+use crate::ffi::arrow_c_ffi::{ArrowArray, ArrowSchema, export_to_c, import_from_c_owned};
+use crate::ffi::arrow_dtype::ArrowType;
+use crate::ffi::schema::Schema;
+use crate::{Array, Field};
+
+/// Export a Minarrow array to a polars `Series`.
+///
+/// `schema.fields[0]` supplies the logical type for the export. The Series
+/// name is taken from `name` (Series carry their own name, separate from
+/// schema field names).
+pub fn export(
+    array: Arc<Array>,
+    name: &str,
+    schema: Schema,
+) -> Result<Series, MinarrowError> {
+    let field_dtype = schema.fields[0].dtype.clone();
+    let (c_arr, c_schema) = export_to_c(array, schema);
+
+    // Move ArrowArray contents into polars_arrow ownership, then free the
+    // boxes allocated by `export_to_c`. The schema box is not consumed by
+    // polars_arrow (we build the dtype manually below), so we run its
+    // release callback explicitly before freeing.
+    let arr_ptr = c_arr as *mut polars_arrow::ffi::ArrowArray;
+    let arr_val = unsafe { std::ptr::read(arr_ptr) };
+    unsafe {
+        drop(Box::from_raw(c_arr));
+        if let Some(release) = (*c_schema).release {
+            release(c_schema);
+        }
+        drop(Box::from_raw(c_schema));
+    }
+
+    let a2_dtype = arrow_type_to_polars_dtype(&field_dtype);
+
+    let a2_array = unsafe {
+        polars_arrow::ffi::import_array_from_c(arr_val, a2_dtype)
+    }
+    .map_err(|e| MinarrowError::BridgeError {
+        source: "polars_arrow",
+        message: format!("import_array_from_c: {e}"),
+    })?;
+
+    Ok(Series::from_arrow(name.into(), a2_array)?)
+}
+
+/// Import a polars `Series` into a Minarrow `(Arc<Array>, Field)`.
+///
+/// Reads chunk 0 of the Series. Callers wanting all chunks should use the
+/// `SuperArray::from_polars` path which iterates over `s.n_chunks()`.
+///
+/// The recovered `Field` has its `name` overridden with `s.name()` so the
+/// Series name round-trips cleanly.
+pub fn import(s: &Series) -> Result<(Arc<Array>, Field), MinarrowError> {
+    let arr2 = s.to_arrow(0, CompatLevel::oldest());
+    import_chunk(s.name().as_str(), s.null_count() > 0, arr2)
+}
+
+/// Import a single polars_arrow `Array` (one chunk) with caller-supplied
+/// name and nullability into a Minarrow `(Arc<Array>, Field)`.
+///
+/// Used by `SuperArray::from_polars` / `SuperTable::from_polars` to consume
+/// per-chunk arrow arrays without rebuilding intermediate Series.
+pub fn import_chunk(
+    name: &str,
+    nullable: bool,
+    arr2: Box<dyn polars_arrow::array::Array>,
+) -> Result<(Arc<Array>, Field), MinarrowError> {
+    let dtype = arr2.dtype().clone();
+    let pa_arr = polars_arrow::ffi::export_array_to_c(arr2);
+    let pa_field =
+        polars_arrow::datatypes::Field::new(name.into(), dtype, nullable);
+    let pa_sch = polars_arrow::ffi::export_field_to_c(&pa_field);
+
+    let arr_ptr = Box::into_raw(Box::new(pa_arr)) as *mut ArrowArray;
+    let sch_ptr = Box::into_raw(Box::new(pa_sch)) as *mut ArrowSchema;
+    let arr_box = unsafe { Box::from_raw(arr_ptr) };
+    let sch_box = unsafe { Box::from_raw(sch_ptr) };
+
+    let (array, mut field) = unsafe { import_from_c_owned(arr_box, sch_box) };
+    field.name = name.to_string();
+    Ok((array, field))
+}
+
+/// Maps a Minarrow `ArrowType` to the corresponding polars_arrow
+/// `ArrowDataType`. Required because polars_arrow's
+/// `import_array_from_c` takes the dtype as a parameter rather than
+/// decoding it from the FFI schema's format string.
+fn arrow_type_to_polars_dtype(dtype: &ArrowType) -> polars_arrow::datatypes::ArrowDataType {
+    use crate::ffi::arrow_dtype::CategoricalIndexType;
+
+    match dtype {
+        ArrowType::Null => polars_arrow::datatypes::ArrowDataType::Null,
+        ArrowType::Boolean => polars_arrow::datatypes::ArrowDataType::Boolean,
+
+        #[cfg(feature = "extended_numeric_types")]
+        ArrowType::Int8 => polars_arrow::datatypes::ArrowDataType::Int8,
+        #[cfg(feature = "extended_numeric_types")]
+        ArrowType::Int16 => polars_arrow::datatypes::ArrowDataType::Int16,
+        ArrowType::Int32 => polars_arrow::datatypes::ArrowDataType::Int32,
+        ArrowType::Int64 => polars_arrow::datatypes::ArrowDataType::Int64,
+
+        #[cfg(feature = "extended_numeric_types")]
+        ArrowType::UInt8 => polars_arrow::datatypes::ArrowDataType::UInt8,
+        #[cfg(feature = "extended_numeric_types")]
+        ArrowType::UInt16 => polars_arrow::datatypes::ArrowDataType::UInt16,
+        ArrowType::UInt32 => polars_arrow::datatypes::ArrowDataType::UInt32,
+        ArrowType::UInt64 => polars_arrow::datatypes::ArrowDataType::UInt64,
+
+        ArrowType::Float32 => polars_arrow::datatypes::ArrowDataType::Float32,
+        ArrowType::Float64 => polars_arrow::datatypes::ArrowDataType::Float64,
+
+        ArrowType::String => polars_arrow::datatypes::ArrowDataType::Utf8,
+        #[cfg(feature = "large_string")]
+        ArrowType::LargeString => polars_arrow::datatypes::ArrowDataType::LargeUtf8,
+        // Utf8View arrays are reshaped to regular Utf8 during the minarrow
+        // import path, so map to Utf8 here.
+        ArrowType::Utf8View => polars_arrow::datatypes::ArrowDataType::Utf8,
+
+        #[cfg(feature = "datetime")]
+        ArrowType::Date32 => polars_arrow::datatypes::ArrowDataType::Date32,
+        #[cfg(feature = "datetime")]
+        ArrowType::Date64 => polars_arrow::datatypes::ArrowDataType::Date64,
+
+        #[cfg(feature = "datetime")]
+        ArrowType::Time32(u) => {
+            polars_arrow::datatypes::ArrowDataType::Time32(match u {
+                crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
+                crate::TimeUnit::Milliseconds => {
+                    polars_arrow::datatypes::TimeUnit::Millisecond
+                }
+                _ => panic!("Time32 supports Seconds or Milliseconds only"),
+            })
+        }
+        #[cfg(feature = "datetime")]
+        ArrowType::Time64(u) => {
+            polars_arrow::datatypes::ArrowDataType::Time64(match u {
+                crate::TimeUnit::Microseconds => {
+                    polars_arrow::datatypes::TimeUnit::Microsecond
+                }
+                crate::TimeUnit::Nanoseconds => {
+                    polars_arrow::datatypes::TimeUnit::Nanosecond
+                }
+                _ => panic!("Time64 supports Microseconds or Nanoseconds only"),
+            })
+        }
+        #[cfg(feature = "datetime")]
+        ArrowType::Duration32(u) => {
+            polars_arrow::datatypes::ArrowDataType::Duration(match u {
+                crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
+                crate::TimeUnit::Milliseconds => {
+                    polars_arrow::datatypes::TimeUnit::Millisecond
+                }
+                _ => panic!("Duration32 supports Seconds or Milliseconds only"),
+            })
+        }
+        #[cfg(feature = "datetime")]
+        ArrowType::Duration64(u) => {
+            polars_arrow::datatypes::ArrowDataType::Duration(match u {
+                crate::TimeUnit::Microseconds => {
+                    polars_arrow::datatypes::TimeUnit::Microsecond
+                }
+                crate::TimeUnit::Nanoseconds => {
+                    polars_arrow::datatypes::TimeUnit::Nanosecond
+                }
+                _ => panic!("Duration64 supports Microseconds or Nanoseconds only"),
+            })
+        }
+        #[cfg(feature = "datetime")]
+        ArrowType::Timestamp(u, tz) => polars_arrow::datatypes::ArrowDataType::Timestamp(
+            match u {
+                crate::TimeUnit::Seconds => polars_arrow::datatypes::TimeUnit::Second,
+                crate::TimeUnit::Milliseconds => {
+                    polars_arrow::datatypes::TimeUnit::Millisecond
+                }
+                crate::TimeUnit::Microseconds => {
+                    polars_arrow::datatypes::TimeUnit::Microsecond
+                }
+                crate::TimeUnit::Nanoseconds => {
+                    polars_arrow::datatypes::TimeUnit::Nanosecond
+                }
+                crate::TimeUnit::Days => panic!("Timestamp(Days) is invalid"),
+            },
+            tz.as_ref().map(|s| s.as_str().into()),
+        ),
+        #[cfg(feature = "datetime")]
+        ArrowType::Interval(iu) => {
+            polars_arrow::datatypes::ArrowDataType::Interval(match iu {
+                crate::IntervalUnit::YearMonth => {
+                    polars_arrow::datatypes::IntervalUnit::YearMonth
+                }
+                crate::IntervalUnit::DaysTime => {
+                    polars_arrow::datatypes::IntervalUnit::DayTime
+                }
+                crate::IntervalUnit::MonthDaysNs => {
+                    polars_arrow::datatypes::IntervalUnit::MonthDayNano
+                }
+            })
+        }
+
+        ArrowType::Dictionary(idx) => {
+            let key: polars_arrow::datatypes::IntegerType = match idx {
+                #[cfg(feature = "default_categorical_8")]
+                CategoricalIndexType::UInt8 => {
+                    polars_arrow::datatypes::IntegerType::UInt8
+                }
+                #[cfg(feature = "extended_categorical")]
+                CategoricalIndexType::UInt16 => {
+                    polars_arrow::datatypes::IntegerType::UInt16
+                }
+                #[cfg(any(
+                    not(feature = "default_categorical_8"),
+                    feature = "extended_categorical"
+                ))]
+                CategoricalIndexType::UInt32 => {
+                    polars_arrow::datatypes::IntegerType::UInt32
+                }
+                #[cfg(feature = "extended_categorical")]
+                CategoricalIndexType::UInt64 => {
+                    polars_arrow::datatypes::IntegerType::UInt64
+                }
+            };
+            polars_arrow::datatypes::ArrowDataType::Dictionary(
+                key,
+                Box::new(polars_arrow::datatypes::ArrowDataType::Utf8),
+                false,
+            )
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,10 @@ pub mod ffi {
     pub mod arrow_c_ffi;
     pub mod arrow_dtype;
     pub mod schema;
+    #[cfg(feature = "cast_arrow")]
+    pub mod arrow_rs;
+    #[cfg(feature = "cast_polars")]
+    pub mod polars;
 }
 
 /// **Type Standardisation** - `MaskedArray`, `View`, `Print` traits + more,

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -27,6 +27,14 @@
 //! - Field metadata is stored once at the SuperArray level, not per-chunk.
 //! - Use `from_arrays()` when you don't need field metadata (e.g., Dam consolidation)
 //! - Use `from_arrays_with_field()` when field metadata is required
+//!
+//! ## Apache Arrow / Polars bridges (`cast_arrow` / `cast_polars` features)
+//! - `to_apache_arrow()` exports each chunk as an arrow-rs `ArrayRef`.
+//! - `to_polars()` builds a polars `Series` whose internal chunks mirror the SuperArray.
+//! - `from_apache_arrow(name, &[ArrayRef])` and `from_polars(&Series)`
+//!   recover dtype + field metadata across chunks.
+//! - Each panicking method has a `try_*` sibling returning `Result<_, MinarrowError>`.
+//! - `&Series` can be converted via `(&series).into()` for ergonomic call sites.
 
 use std::fmt::{Display, Formatter};
 use std::iter::FromIterator;
@@ -1086,6 +1094,178 @@ impl Concatenate for SuperArray {
             field: self.field.or(other.field),
             null_counts,
         })
+    }
+}
+
+// ===========================================================
+// Apache Arrow / Polars bridges for SuperArray
+// ===========================================================
+
+impl SuperArray {
+    /// Export each chunk as an arrow-rs `ArrayRef`. The resulting `Vec` has the
+    /// same length as `self.n_chunks()`. Field metadata travels with each chunk
+    /// when the SuperArray was built with one.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperArray::try_to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn to_apache_arrow(&self) -> Vec<arrow::array::ArrayRef> {
+        self.try_to_apache_arrow()
+            .expect("SuperArray::to_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`SuperArray::to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_to_apache_arrow(
+        &self,
+    ) -> Result<Vec<arrow::array::ArrayRef>, MinarrowError> {
+        let mut out = Vec::with_capacity(self.chunks.len());
+        // When a field is present, use it so logical types (Timestamp/Time/etc)
+        // are preserved across chunks. Otherwise derive per chunk from shape.
+        match self.field.as_deref() {
+            Some(field) => {
+                for chunk in &self.chunks {
+                    out.push(crate::ffi::arrow_rs::export(
+                        Arc::new(chunk.clone()),
+                        crate::ffi::schema::Schema::from(vec![field.clone()]),
+                    )?);
+                }
+            }
+            None => {
+                for chunk in &self.chunks {
+                    out.push(chunk.try_to_apache_arrow("")?);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Build a polars `Series` whose internal arrow chunks mirror the
+    /// SuperArray's chunks. Requires a stored field for the name.
+    ///
+    /// Panics on FFI failure or missing field metadata. For a fallible variant,
+    /// see [`SuperArray::try_to_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn to_polars(&self) -> polars::prelude::Series {
+        self.try_to_polars().expect("SuperArray::to_polars failed")
+    }
+
+    /// Fallible variant of [`SuperArray::to_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_to_polars(
+        &self,
+    ) -> Result<polars::prelude::Series, MinarrowError> {
+        let field = self.field.as_deref().ok_or_else(|| MinarrowError::TypeError {
+            from: "SuperArray",
+            to: "polars::Series",
+            message: Some("SuperArray has no field metadata; assign one before exporting".into()),
+        })?;
+        let schema = crate::ffi::schema::Schema::from(vec![field.clone()]);
+
+        if self.chunks.is_empty() {
+            // Build an empty Series with the right dtype via an empty chunk.
+            return crate::ffi::polars::export(
+                Arc::new(Array::Null),
+                &field.name,
+                schema,
+            );
+        }
+
+        // Build a Series per chunk, then concatenate via polars to preserve chunks.
+        let mut iter = self.chunks.iter();
+        let first = crate::ffi::polars::export(
+            Arc::new(iter.next().unwrap().clone()),
+            &field.name,
+            schema.clone(),
+        )?;
+        let mut acc = first;
+        for chunk in iter {
+            let s = crate::ffi::polars::export(
+                Arc::new(chunk.clone()),
+                &field.name,
+                schema.clone(),
+            )?;
+            acc.append(&s)?;
+        }
+        Ok(acc)
+    }
+
+    /// Build a `SuperArray` from arrow-rs chunks sharing a single column name.
+    ///
+    /// The schema of each chunk must match. Dtype, nullability, and any custom
+    /// metadata are recovered from the first chunk.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperArray::try_from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn from_apache_arrow(
+        name: impl Into<String>,
+        chunks: &[arrow::array::ArrayRef],
+    ) -> SuperArray {
+        Self::try_from_apache_arrow(name, chunks)
+            .expect("SuperArray::from_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`SuperArray::from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_from_apache_arrow(
+        name: impl Into<String>,
+        chunks: &[arrow::array::ArrayRef],
+    ) -> Result<SuperArray, MinarrowError> {
+        let name: String = name.into();
+        if chunks.is_empty() {
+            return Ok(SuperArray::new());
+        }
+        let mut field_arrays = Vec::with_capacity(chunks.len());
+        for c in chunks {
+            field_arrays.push(FieldArray::try_from_apache_arrow(name.clone(), c)?);
+        }
+        Ok(SuperArray::from_field_array_chunks(field_arrays))
+    }
+
+    /// Build a `SuperArray` from a Polars `Series`, preserving the Series'
+    /// internal chunk boundaries.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperArray::try_from_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn from_polars(s: &polars::prelude::Series) -> SuperArray {
+        Self::try_from_polars(s).expect("SuperArray::from_polars failed")
+    }
+
+    /// Fallible variant of [`SuperArray::from_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_from_polars(
+        s: &polars::prelude::Series,
+    ) -> Result<SuperArray, MinarrowError> {
+        use polars::prelude::CompatLevel;
+        let n = s.n_chunks();
+        if n == 0 {
+            return Ok(SuperArray::new());
+        }
+        let name = s.name().as_str().to_string();
+        let nullable = s.null_count() > 0;
+
+        let mut field_arrays = Vec::with_capacity(n);
+        for i in 0..n {
+            let arr2 = s.to_arrow(i, CompatLevel::oldest());
+            let (array_arc, field) =
+                crate::ffi::polars::import_chunk(&name, nullable, arr2)?;
+            let array = Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone());
+            field_arrays.push(FieldArray::new(field, array));
+        }
+        Ok(SuperArray::from_field_array_chunks(field_arrays))
+    }
+}
+
+#[cfg(feature = "cast_polars")]
+impl From<&polars::prelude::Series> for SuperArray {
+    fn from(s: &polars::prelude::Series) -> Self {
+        SuperArray::from_polars(s)
     }
 }
 

--- a/src/structs/chunked/super_table.rs
+++ b/src/structs/chunked/super_table.rs
@@ -32,6 +32,16 @@
 //! - Streaming ingestion into append-only datasets.
 //! - Windowed or mini-batch analytics.
 //! - Incremental build-up of tables for later unification.
+//!
+//! ## Apache Arrow / Polars bridges (`cast_arrow` / `cast_polars` features)
+//! - `to_apache_arrow()` exports each batch as an arrow-rs `RecordBatch`.
+//! - `to_polars()` builds a polars `DataFrame` whose columns are chunked Series
+//!   mirroring the SuperTable's batches.
+//! - `from_apache_arrow(&[RecordBatch])` and `from_polars(&DataFrame)`
+//!   recover schema, dtypes, and chunk boundaries on import.
+//! - Each panicking method has a `try_*` sibling returning `Result<_, MinarrowError>`.
+//! - `&[RecordBatch]` and `&DataFrame` can be converted via `.into()` for
+//!   ergonomic call sites.
 
 use std::fmt::{Display, Formatter};
 
@@ -879,6 +889,191 @@ impl Display for SuperTable {
         }
 
         Ok(())
+    }
+}
+
+// ===========================================================
+// Apache Arrow / Polars bridges for SuperTable
+// ===========================================================
+
+impl SuperTable {
+    /// Export each batch as an arrow-rs `RecordBatch`.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperTable::try_to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn to_apache_arrow(&self) -> Vec<arrow::array::RecordBatch> {
+        self.try_to_apache_arrow()
+            .expect("SuperTable::to_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`SuperTable::to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_to_apache_arrow(
+        &self,
+    ) -> Result<Vec<arrow::array::RecordBatch>, MinarrowError> {
+        let mut out = Vec::with_capacity(self.batches.len());
+        for batch in &self.batches {
+            out.push(batch.try_to_apache_arrow()?);
+        }
+        Ok(out)
+    }
+
+    /// Build a polars `DataFrame` whose columns are chunked Series mirroring
+    /// the SuperTable's batches.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperTable::try_to_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn to_polars(&self) -> polars::frame::DataFrame {
+        self.try_to_polars()
+            .expect("SuperTable::to_polars failed")
+    }
+
+    /// Fallible variant of [`SuperTable::to_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_to_polars(
+        &self,
+    ) -> Result<polars::frame::DataFrame, MinarrowError> {
+        use polars::prelude::Column;
+        if self.batches.is_empty() {
+            // Build an empty DataFrame matching the schema.
+            return Ok(polars::frame::DataFrame::default());
+        }
+
+        let n_cols = self.batches[0].n_cols();
+        let mut col_series: Vec<polars::prelude::Series> =
+            Vec::with_capacity(n_cols);
+
+        // Per column, fold per-batch Series via `append` so chunks survive.
+        for col_idx in 0..n_cols {
+            let mut iter = self.batches.iter();
+            let first_batch = iter.next().unwrap();
+            let mut acc = first_batch.cols[col_idx].try_to_polars()?;
+            for batch in iter {
+                let s = batch.cols[col_idx].try_to_polars()?;
+                acc.append(&s)?;
+            }
+            col_series.push(acc);
+        }
+
+        let cols: Vec<Column> = col_series
+            .into_iter()
+            .map(|s| Column::new(s.name().clone(), s))
+            .collect();
+        Ok(polars::frame::DataFrame::new(self.n_rows, cols)?)
+    }
+
+    /// Build a `SuperTable` from a slice of arrow-rs `RecordBatch` values.
+    /// All batches must share the same schema.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperTable::try_from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn from_apache_arrow(
+        batches: &[arrow::array::RecordBatch],
+    ) -> SuperTable {
+        Self::try_from_apache_arrow(batches)
+            .expect("SuperTable::from_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`SuperTable::from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_from_apache_arrow(
+        batches: &[arrow::array::RecordBatch],
+    ) -> Result<SuperTable, MinarrowError> {
+        if batches.is_empty() {
+            return Ok(SuperTable::new(String::new()));
+        }
+        let mut tables = Vec::with_capacity(batches.len());
+        for rb in batches {
+            tables.push(Arc::new(Table::try_from_apache_arrow(rb)?));
+        }
+        Ok(SuperTable::from_batches(tables, None))
+    }
+
+    /// Build a `SuperTable` from a Polars `DataFrame`, preserving per-column
+    /// chunk boundaries as separate batches.
+    ///
+    /// All columns must share the same number of chunks for this to map cleanly
+    /// to batches; if chunks are misaligned across columns we re-chunk the
+    /// DataFrame to a single chunk first as a fallback.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`SuperTable::try_from_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn from_polars(df: &polars::frame::DataFrame) -> SuperTable {
+        Self::try_from_polars(df)
+            .expect("SuperTable::from_polars failed")
+    }
+
+    /// Fallible variant of [`SuperTable::from_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_from_polars(
+        df: &polars::frame::DataFrame,
+    ) -> Result<SuperTable, MinarrowError> {
+        let columns = df.columns();
+        if columns.is_empty() {
+            return Ok(SuperTable::new(String::new()));
+        }
+
+        // Materialise each column to a Series and read its chunk count.
+        let series: Vec<&polars::prelude::Series> = columns
+            .iter()
+            .map(|c| c.as_materialized_series())
+            .collect();
+        let n_chunks = series[0].n_chunks();
+        let aligned = series.iter().all(|s| s.n_chunks() == n_chunks);
+
+        if !aligned {
+            // Misaligned chunks: fall back to a single-batch SuperTable built
+            // from a rechunked DataFrame. We rebuild via Table::from_polars
+            // which calls per-column FieldArray::try_from_polars (which itself
+            // uses chunk 0; for misaligned multi-chunk Series, we rechunk).
+            let mut rechunked = df.clone();
+            rechunked.align_chunks_par();
+            let table = Table::try_from_polars(&rechunked)?;
+            return Ok(SuperTable::from_batches(vec![Arc::new(table)], None));
+        }
+
+        // Aligned: build one Table per chunk index by importing the i'th
+        // chunk of each Series directly through the polars bridge.
+        use polars::prelude::CompatLevel;
+        let mut batches = Vec::with_capacity(n_chunks);
+        for chunk_idx in 0..n_chunks {
+            let mut cols = Vec::with_capacity(series.len());
+            for s in &series {
+                let arr2 = s.to_arrow(chunk_idx, CompatLevel::oldest());
+                let (array_arc, field) = crate::ffi::polars::import_chunk(
+                    s.name().as_str(),
+                    s.null_count() > 0,
+                    arr2,
+                )?;
+                let array =
+                    Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone());
+                cols.push(FieldArray::new(field, array));
+            }
+            batches.push(Arc::new(Table::new(String::new(), Some(cols))));
+        }
+        Ok(SuperTable::from_batches(batches, None))
+    }
+}
+
+#[cfg(feature = "cast_arrow")]
+impl From<&[arrow::array::RecordBatch]> for SuperTable {
+    fn from(batches: &[arrow::array::RecordBatch]) -> Self {
+        SuperTable::from_apache_arrow(batches)
+    }
+}
+
+#[cfg(feature = "cast_polars")]
+impl From<&polars::frame::DataFrame> for SuperTable {
+    fn from(df: &polars::frame::DataFrame) -> Self {
+        SuperTable::from_polars(df)
     }
 }
 

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -17,11 +17,22 @@
 //! Couples a `Field` (i.e., array-level schema metadata) with an immutable `Array` of values.
 //!
 //! Used as the primary column representation in `Minarrow` tables, ensuring
-//! schema and data remain consistent.  
+//! schema and data remain consistent.
 //!
 //! Supports creation from raw components or by inferring schema from arrays,
 //! and is the unit transferred over Arrow FFI or to external libraries
 //! such as Apache Arrow or Polars.
+//!
+//! ## Apache Arrow / Polars bridges (`cast_arrow` / `cast_polars` features)
+//!
+//! - `to_apache_arrow()` / `to_polars()` export with the stored `Field`, so
+//!   Timestamp/Time/Duration/Interval logical types round-trip correctly.
+//! - `from_apache_arrow(name, &ArrayRef)` and `from_polars(&Series)` recover
+//!   dtype, nullability, and any custom field metadata from the FFI schema.
+//!   For polars, the column name comes from `s.name()`.
+//! - Each panicking method has a `try_*` sibling returning
+//!   `Result<_, MinarrowError>`. `&Series` can also be converted via
+//!   `(&series).into()` for ergonomic call sites.
 
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
@@ -298,20 +309,116 @@ impl FieldArray {
         result
     }
 
-    /// Export this field+array over FFI and import into arrow-rs.
+    /// Export this field+array over Arrow C-FFI and import into arrow-rs.
+    ///
+    /// Carries the stored `Field` through the conversion, preserving logical
+    /// types such as Timestamp/Time/Duration/Interval.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`FieldArray::try_to_apache_arrow`].
     #[cfg(feature = "cast_arrow")]
     #[inline]
     pub fn to_apache_arrow(&self) -> ArrayRef {
-        self.array.to_apache_arrow_with_field(&self.field)
+        self.try_to_apache_arrow()
+            .expect("FieldArray::to_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`FieldArray::to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn try_to_apache_arrow(&self) -> Result<ArrayRef, MinarrowError> {
+        crate::ffi::arrow_rs::export(
+            Arc::new(self.array.clone()),
+            crate::ffi::schema::Schema::from(vec![(*self.field).clone()]),
+        )
     }
 
     // ** The below polars function is tested tests/polars.rs **
 
-    /// Casts the FieldArray to a polars Series
+    /// Casts the FieldArray to a polars Series, preserving the stored `Field`.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`FieldArray::try_to_polars`].
     #[cfg(feature = "cast_polars")]
     pub fn to_polars(&self) -> Series {
-        let name = self.field.name.as_str();
-        self.array.to_polars_with_field(name, &self.field)
+        self.try_to_polars().expect("FieldArray::to_polars failed")
+    }
+
+    /// Fallible variant of [`FieldArray::to_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_to_polars(&self) -> Result<Series, MinarrowError> {
+        crate::ffi::polars::export(
+            Arc::new(self.array.clone()),
+            self.field.name.as_str(),
+            crate::ffi::schema::Schema::from(vec![(*self.field).clone()]),
+        )
+    }
+
+    // ===========================================================
+    // Apache Arrow / Polars import (`from_*`)
+    // ===========================================================
+
+    /// Build a `FieldArray` from an arrow-rs `ArrayRef` and a column name.
+    ///
+    /// arrow-rs `ArrayRef` does not carry a column name (only `Schema`/`Field` do),
+    /// so the caller must provide one. Dtype, nullability, and any custom metadata
+    /// are recovered from the FFI schema.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`FieldArray::try_from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn from_apache_arrow(
+        name: impl Into<String>,
+        arr: &arrow::array::ArrayRef,
+    ) -> FieldArray {
+        Self::try_from_apache_arrow(name, arr)
+            .expect("FieldArray::from_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`FieldArray::from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_from_apache_arrow(
+        name: impl Into<String>,
+        arr: &arrow::array::ArrayRef,
+    ) -> Result<FieldArray, MinarrowError> {
+        let (array_arc, mut field) = crate::ffi::arrow_rs::import(arr)?;
+        field.name = name.into();
+        let array = Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone());
+        Ok(FieldArray::new(field, array))
+    }
+
+    /// Build a `FieldArray` from a Polars `Series`.
+    ///
+    /// Name comes from `s.name()`. Dtype, nullability, and any custom metadata
+    /// are recovered from the FFI schema.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`FieldArray::try_from_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn from_polars(s: &polars::prelude::Series) -> FieldArray {
+        Self::try_from_polars(s).expect("FieldArray::from_polars failed")
+    }
+
+    /// Fallible variant of [`FieldArray::from_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_from_polars(
+        s: &polars::prelude::Series,
+    ) -> Result<FieldArray, MinarrowError> {
+        let (array_arc, field) = crate::ffi::polars::import(s)?;
+        let array = Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone());
+        Ok(FieldArray::new(field, array))
+    }
+}
+
+// Provides `(&series).into()` ergonomics for building a FieldArray.
+// Panics on FFI failure - users who want the fallible flavour should call
+// the named `FieldArray::try_from_polars(&s)?` method instead.
+#[cfg(feature = "cast_polars")]
+impl From<&polars::prelude::Series> for FieldArray {
+    fn from(s: &polars::prelude::Series) -> Self {
+        FieldArray::from_polars(s)
     }
 }
 

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -24,7 +24,10 @@
 //! and zero-copy FFI interchange.
 //!
 //! Cast into *Polars* dataframe via `.to_polars()` or *Apache Arrow* RecordBatch via `.to_apache_arrow()`,
-//! zero-copy, via the `cast_polars` and `cast_arrow` features.
+//! zero-copy, via the `cast_polars` and `cast_arrow` features. Round-trip the
+//! other direction with `Table::from_polars(&df)` or `Table::from_apache_arrow(&rb)`,
+//! or call `(&df).into()` / `(&rb).into()`. Each has a `try_*` sibling returning
+//! `Result<_, MinarrowError>`.
 
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
@@ -680,22 +683,31 @@ impl Table {
     ///
     /// The Arrow schema is derived from the imported array dtypes while
     /// preserving the original field names and nullability flags.
+    ///
+    /// Panics on FFI failure or empty table. For a fallible variant, see
+    /// [`Table::try_to_apache_arrow`].
     #[cfg(feature = "cast_arrow")]
     #[inline]
     pub fn to_apache_arrow(&self) -> RecordBatch {
-        use arrow::array::ArrayRef;
-        assert!(
-            !self.cols.is_empty(),
-            "Cannot build RecordBatch from an empty Table"
-        );
+        self.try_to_apache_arrow()
+            .expect("Table::to_apache_arrow failed")
+    }
 
-        // Convert columns
-        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.cols.len());
-        for col in &self.cols {
-            arrays.push(col.to_apache_arrow());
+    /// Fallible variant of [`Table::to_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_to_apache_arrow(&self) -> Result<RecordBatch, MinarrowError> {
+        use arrow::array::ArrayRef;
+        if self.cols.is_empty() {
+            return Err(MinarrowError::ShapeError {
+                message: "cannot build RecordBatch from an empty Table".to_string(),
+            });
         }
 
-        // Build Arrow Schema using field names + imported dtypes
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.cols.len());
+        for col in &self.cols {
+            arrays.push(col.try_to_apache_arrow()?);
+        }
+
         let mut fields = Vec::with_capacity(self.cols.len());
         for (i, col) in self.cols.iter().enumerate() {
             let dt = arrays[i].data_type().clone();
@@ -707,21 +719,99 @@ impl Table {
         }
         let schema = Arc::new(arrow_schema::Schema::new(fields));
 
-        // Assemble batch
-        RecordBatch::try_new(schema, arrays).expect("Failed to build RecordBatch from Table")
+        Ok(RecordBatch::try_new(schema, arrays)?)
     }
 
     // ** The below polars function is tested tests/polars.rs **
 
-    /// Casts the table to a Polars DataFrame
+    /// Casts the table to a Polars DataFrame.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Table::try_to_polars`].
     #[cfg(feature = "cast_polars")]
     pub fn to_polars(&self) -> DataFrame {
-        let cols = self
-            .cols
-            .iter()
-            .map(|fa| Column::new(fa.field.name.clone().into(), fa.to_polars()))
-            .collect::<Vec<_>>();
-        DataFrame::new(self.n_rows, cols).expect("DataFrame build failed")
+        self.try_to_polars().expect("Table::to_polars failed")
+    }
+
+    /// Fallible variant of [`Table::to_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_to_polars(&self) -> Result<DataFrame, MinarrowError> {
+        let mut cols = Vec::with_capacity(self.cols.len());
+        for fa in &self.cols {
+            let series = fa.try_to_polars()?;
+            cols.push(Column::new(fa.field.name.clone().into(), series));
+        }
+        Ok(DataFrame::new(self.n_rows, cols)?)
+    }
+
+    // ===========================================================
+    // Apache Arrow / Polars import (`from_*`)
+    // ===========================================================
+
+    /// Build a `Table` from an arrow-rs `RecordBatch`. Column names, dtypes,
+    /// nullability, and any custom field metadata are recovered from the
+    /// RecordBatch schema. The Table name will be empty; assign one via
+    /// `Table::new` if needed.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Table::try_from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    #[inline]
+    pub fn from_apache_arrow(rb: &RecordBatch) -> Table {
+        Self::try_from_apache_arrow(rb).expect("Table::from_apache_arrow failed")
+    }
+
+    /// Fallible variant of [`Table::from_apache_arrow`].
+    #[cfg(feature = "cast_arrow")]
+    pub fn try_from_apache_arrow(rb: &RecordBatch) -> Result<Table, MinarrowError> {
+        let schema = rb.schema();
+        let mut cols = Vec::with_capacity(rb.num_columns());
+        for (i, col) in rb.columns().iter().enumerate() {
+            let arr_field = schema.field(i);
+            let fa = FieldArray::try_from_apache_arrow(arr_field.name(), col)?;
+            cols.push(fa);
+        }
+        Ok(Table::new(String::new(), Some(cols)))
+    }
+
+    /// Build a `Table` from a Polars `DataFrame`. Column names, dtypes,
+    /// nullability, and any custom Series metadata are recovered.
+    ///
+    /// Panics on FFI failure. For a fallible variant, see
+    /// [`Table::try_from_polars`].
+    #[cfg(feature = "cast_polars")]
+    #[inline]
+    pub fn from_polars(df: &DataFrame) -> Table {
+        Self::try_from_polars(df).expect("Table::from_polars failed")
+    }
+
+    /// Fallible variant of [`Table::from_polars`].
+    #[cfg(feature = "cast_polars")]
+    pub fn try_from_polars(df: &DataFrame) -> Result<Table, MinarrowError> {
+        let columns = df.columns();
+        let mut cols = Vec::with_capacity(columns.len());
+        for column in columns {
+            // Polars Column owns its data either as a Series or scalar; materialise
+            // into a single chunked Series so we can hit the polars_arrow FFI path.
+            let series = column.as_materialized_series();
+            let fa = FieldArray::try_from_polars(series)?;
+            cols.push(fa);
+        }
+        Ok(Table::new(String::new(), Some(cols)))
+    }
+}
+
+#[cfg(feature = "cast_arrow")]
+impl From<&RecordBatch> for Table {
+    fn from(rb: &RecordBatch) -> Self {
+        Table::from_apache_arrow(rb)
+    }
+}
+
+#[cfg(feature = "cast_polars")]
+impl From<&DataFrame> for Table {
+    fn from(df: &DataFrame) -> Self {
+        Table::from_polars(df)
     }
 }
 

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -26,7 +26,8 @@ use arrow::datatypes::{DataType as ADataType, TimeUnit as ATimeUnit};
 use arrow::record_batch::RecordBatch;
 
 use minarrow::{
-    fa_i32, fa_str32, fa_u32, Array as MArray, ArrowType, Field, NumericArray, Table, TextArray,
+    fa_i32, fa_str32, fa_u32, Array as MArray, ArrowType, Field, FieldArray, NumericArray, Table,
+    TextArray,
 };
 
 #[cfg(feature = "datetime")]
@@ -98,7 +99,7 @@ fn test_array_to_arrow_datetime_infer_time32s() {
         },
     )));
     let f = Field::new("t32s", ArrowType::Time32(TimeUnit::Seconds), false, None);
-    let ar = a.to_apache_arrow_with_field(&f);
+    let ar = FieldArray::new(f, a).to_apache_arrow();
 
     assert_eq!(ar.data_type(), &ADataType::Time32(ATimeUnit::Second));
     let col = ar.as_any().downcast_ref::<Time32SecondArray>().unwrap();
@@ -140,7 +141,7 @@ fn test_array_to_arrow_datetime_infer_date64_and_ts_ns() {
         false,
         None,
     );
-    let ar_ns = a_ns.to_apache_arrow_with_field(&f_tsns);
+    let ar_ns = FieldArray::new(f_tsns, a_ns).to_apache_arrow();
     assert_eq!(
         ar_ns.data_type(),
         &ADataType::Timestamp(ATimeUnit::Nanosecond, None)
@@ -156,11 +157,11 @@ fn test_array_to_arrow_datetime_infer_date64_and_ts_ns() {
 }
 
 #[test]
-fn test_array_to_arrow_with_field_explicit() {
+fn test_array_to_arrow_with_field_via_field_array() {
     let arr = Arc::new(minarrow::IntegerArray::<i64>::from_slice(&[10, 20]));
     let a = MArray::NumericArray(NumericArray::Int64(arr));
     let f = Field::new("y", ArrowType::Int64, false, None);
-    let ar = a.to_apache_arrow_with_field(&f);
+    let ar = FieldArray::new(f, a).to_apache_arrow();
 
     assert_eq!(ar.data_type(), &ADataType::Int64);
     let col = ar.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -181,6 +182,174 @@ fn test_fieldarray_to_arrow() {
     assert_eq!(col.value(0), 5);
     assert_eq!(col.value(1), 6);
     assert_eq!(col.value(2), 7);
+}
+
+// =============================================================
+// Round-trip tests: arrow-rs -> Minarrow (from_*) -> arrow-rs
+// =============================================================
+
+#[test]
+fn test_array_from_arrow_round_trip_numeric() {
+    let arr = Arc::new(minarrow::IntegerArray::<i32>::from_slice(&[1, 2, 3, 4]));
+    let original = MArray::NumericArray(NumericArray::Int32(arr));
+
+    // Export to arrow-rs, then re-import as bare Array (field metadata dropped)
+    let arrow_ref = original.to_apache_arrow("x");
+    let back = MArray::from_apache_arrow(&arrow_ref);
+
+    assert_eq!(original, back);
+}
+
+#[test]
+fn test_array_from_arrow_round_trip_string() {
+    let arr = Arc::new(minarrow::StringArray::<u32>::from_slice(&["foo", "bar", ""]));
+    let original = MArray::TextArray(TextArray::String32(arr));
+    let arrow_ref = original.to_apache_arrow("s");
+    let back = MArray::from_apache_arrow(&arrow_ref);
+    assert_eq!(original, back);
+}
+
+#[test]
+fn test_field_array_from_arrow_round_trip_preserves_field() {
+    let fa = fa_i32!("x", 10, 20, 30);
+    let arrow_ref = fa.to_apache_arrow();
+    let back = FieldArray::from_apache_arrow("x", &arrow_ref);
+
+    assert_eq!(back.field.name, "x");
+    assert_eq!(back.field.dtype, ArrowType::Int32);
+    assert_eq!(back.len(), 3);
+    assert_eq!(back.array, fa.array);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn test_field_array_from_arrow_round_trip_timestamp() {
+    let dt = MArray::TemporalArray(TemporalArray::Datetime64(Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1, 2, 3]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let field = Field::new(
+        "ts_ns",
+        ArrowType::Timestamp(TimeUnit::Nanoseconds, None),
+        false,
+        None,
+    );
+    let fa = FieldArray::new(field.clone(), dt);
+
+    let arrow_ref = fa.to_apache_arrow();
+    let back = FieldArray::from_apache_arrow("ts_ns", &arrow_ref);
+
+    assert_eq!(back.field.name, "ts_ns");
+    assert_eq!(
+        back.field.dtype,
+        ArrowType::Timestamp(TimeUnit::Nanoseconds, None)
+    );
+}
+
+#[test]
+fn test_table_from_arrow_round_trip() {
+    let c1 = fa_i32!("a", 1, 2, 3);
+    let c2 = fa_str32!("b", "x", "y", "z");
+    let original = Table::new("t".into(), Some(vec![c1, c2]));
+
+    let rb: RecordBatch = original.to_apache_arrow();
+    let back = Table::from_apache_arrow(&rb);
+
+    assert_eq!(back.n_rows(), 3);
+    assert_eq!(back.n_cols(), 2);
+    assert_eq!(back.col_names(), &["a", "b"]);
+    for (lhs, rhs) in original.cols.iter().zip(back.cols.iter()) {
+        assert_eq!(lhs.field.dtype, rhs.field.dtype);
+        assert_eq!(lhs.array, rhs.array);
+    }
+}
+
+#[test]
+fn test_table_from_arrow_via_into() {
+    let c1 = fa_i32!("a", 1, 2);
+    let original = Table::new("t".into(), Some(vec![c1]));
+    let rb: RecordBatch = original.to_apache_arrow();
+    let back: Table = (&rb).into();
+    assert_eq!(back.n_rows(), 2);
+    assert_eq!(back.cols[0].field.name, "a");
+}
+
+#[test]
+fn test_try_from_arrow_returns_ok() {
+    let fa = fa_u32!("u", 5, 6, 7);
+    let arrow_ref = fa.to_apache_arrow();
+    let back = MArray::try_from_apache_arrow(&arrow_ref).unwrap();
+    assert_eq!(back.len(), 3);
+}
+
+// =============================================================
+// SuperArray / SuperTable round-trip tests
+// =============================================================
+
+#[cfg(feature = "chunked")]
+#[test]
+fn test_super_array_apache_arrow_round_trip() {
+    use minarrow::SuperArray;
+    let fa1 = fa_i32!("a", 1, 2, 3);
+    let fa2 = fa_i32!("a", 4, 5);
+    let sa = SuperArray::from_field_array_chunks(vec![fa1, fa2]);
+
+    let chunks: Vec<ArrayRef> = sa.to_apache_arrow();
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(chunks[0].len(), 3);
+    assert_eq!(chunks[1].len(), 2);
+
+    let back = SuperArray::from_apache_arrow("a", &chunks);
+    assert_eq!(back.n_chunks(), 2);
+    assert_eq!(back.len(), 5);
+    assert_eq!(back.field_ref().name, "a");
+    assert_eq!(back.field_ref().dtype, ArrowType::Int32);
+}
+
+#[cfg(feature = "chunked")]
+#[test]
+fn test_super_table_apache_arrow_round_trip() {
+    use minarrow::SuperTable;
+    use std::sync::Arc;
+
+    let c1a = fa_i32!("a", 1, 2);
+    let c2a = fa_str32!("b", "x", "y");
+    let batch1 = Table::new("".into(), Some(vec![c1a, c2a]));
+
+    let c1b = fa_i32!("a", 3, 4, 5);
+    let c2b = fa_str32!("b", "z", "w", "v");
+    let batch2 = Table::new("".into(), Some(vec![c1b, c2b]));
+
+    let st = SuperTable::from_batches(vec![Arc::new(batch1), Arc::new(batch2)], None);
+
+    let rbs: Vec<RecordBatch> = st.to_apache_arrow();
+    assert_eq!(rbs.len(), 2);
+    assert_eq!(rbs[0].num_rows(), 2);
+    assert_eq!(rbs[1].num_rows(), 3);
+
+    let back = SuperTable::from_apache_arrow(&rbs);
+    assert_eq!(back.n_batches(), 2);
+    assert_eq!(back.n_rows(), 5);
+    assert_eq!(back.n_cols(), 2);
+    assert_eq!(back.batches()[0].n_rows(), 2);
+    assert_eq!(back.batches()[1].n_rows(), 3);
+}
+
+#[cfg(feature = "chunked")]
+#[test]
+fn test_super_table_apache_arrow_via_into() {
+    use minarrow::SuperTable;
+    use std::sync::Arc;
+    let c1 = fa_i32!("a", 1, 2);
+    let batch = Table::new("".into(), Some(vec![c1]));
+    let st = SuperTable::from_batches(vec![Arc::new(batch)], None);
+    let rbs: Vec<RecordBatch> = st.to_apache_arrow();
+    let back: SuperTable = rbs.as_slice().into();
+    assert_eq!(back.n_batches(), 1);
+    assert_eq!(back.n_rows(), 2);
 }
 
 #[test]

--- a/tests/polars.rs
+++ b/tests/polars.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 
 use minarrow::{
-    fa_i32, fa_str32, fa_u32, Array, ArrowType, Field, NumericArray, Table, TextArray,
+    fa_i32, fa_str32, fa_u32, Array, ArrowType, Field, MaskedArray, NumericArray, Table, TextArray,
 };
 #[cfg(feature = "datetime")]
 use minarrow::{TemporalArray, TimeUnit};
@@ -113,11 +113,12 @@ fn test_array_to_polars_datetime_infer_date64_or_ts() {
 }
 
 #[test]
-fn test_array_to_polars_with_field_explicit() {
+fn test_array_to_polars_with_field_via_field_array() {
+    use minarrow::FieldArray;
     let arr = Arc::new(minarrow::IntegerArray::<i64>::from_slice(&[10, 20]));
     let a = Array::NumericArray(NumericArray::Int64(arr));
     let f = Field::new("y", ArrowType::Int64, false, None);
-    let s = a.to_polars_with_field("y", &f);
+    let s = FieldArray::new(f, a).to_polars();
     assert_eq!(s.dtype(), &DataType::Int64);
     assert_eq!(
         s.i64().unwrap().into_no_null_iter().collect::<Vec<_>>(),
@@ -143,4 +144,133 @@ fn test_table_to_polars() {
     assert_eq!(df.height(), 2);
     assert_eq!(df.width(), 2);
     assert_eq!(df.get_column_names(), &["a", "b"]);
+}
+
+// =============================================================
+// Round-trip tests: polars -> Minarrow (from_*) -> polars
+// =============================================================
+
+#[test]
+fn test_array_from_polars_round_trip_numeric() {
+    let arr = Arc::new(minarrow::IntegerArray::<i32>::from_slice(&[1, 2, 3, 4]));
+    let original = Array::NumericArray(NumericArray::Int32(arr));
+
+    let s = original.to_polars("x");
+    let back = Array::from_polars(&s);
+    assert_eq!(original, back);
+}
+
+#[test]
+fn test_array_from_polars_round_trip_string() {
+    let arr = Arc::new(minarrow::StringArray::<u32>::from_slice(&["foo", "bar", "baz"]));
+    let original = Array::TextArray(TextArray::String32(arr));
+    let s = original.to_polars("s");
+    let back = Array::from_polars(&s);
+
+    // Polars may upcast Utf8 -> LargeUtf8 (string offset width changes).
+    // Compare element-wise to be width-agnostic.
+    let back_str: Vec<String> = match &back {
+        Array::TextArray(TextArray::String32(b)) => (0..b.len())
+            .map(|i| b.get_str(i).unwrap_or("").to_string())
+            .collect(),
+        Array::TextArray(TextArray::String64(b)) => (0..b.len())
+            .map(|i| b.get_str(i).unwrap_or("").to_string())
+            .collect(),
+        _ => panic!("expected string array, got {:?}", back),
+    };
+    assert_eq!(
+        back_str,
+        vec!["foo".to_string(), "bar".to_string(), "baz".to_string()]
+    );
+}
+
+#[test]
+fn test_field_array_from_polars_round_trip_preserves_name() {
+    use minarrow::FieldArray;
+    let fa = minarrow::fa_i32!("score", 10, 20, 30);
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.name, "score");
+    assert_eq!(back.field.dtype, ArrowType::Int32);
+    assert_eq!(back.len(), 3);
+    assert_eq!(back.array, fa.array);
+}
+
+#[test]
+fn test_field_array_from_polars_via_into() {
+    use minarrow::FieldArray;
+    let fa = minarrow::fa_u32!("u", 5, 6, 7);
+    let s = fa.to_polars();
+    let back: FieldArray = (&s).into();
+    assert_eq!(back.field.name, "u");
+    assert_eq!(back.len(), 3);
+}
+
+#[test]
+fn test_table_from_polars_round_trip() {
+    let c1 = fa_i32!("a", 1, 2, 3);
+    let c2 = fa_str32!("b", "x", "y", "z");
+    let original = Table::new("t".into(), Some(vec![c1, c2]));
+
+    let df = original.to_polars();
+    let back = Table::from_polars(&df);
+
+    assert_eq!(back.n_rows(), 3);
+    assert_eq!(back.n_cols(), 2);
+    assert_eq!(back.col_names(), &["a", "b"]);
+    assert_eq!(back.cols[0].field.dtype, ArrowType::Int32);
+}
+
+#[test]
+fn test_table_from_polars_via_into() {
+    let c1 = fa_i32!("a", 1, 2);
+    let original = Table::new("t".into(), Some(vec![c1]));
+    let df = original.to_polars();
+    let back: Table = (&df).into();
+    assert_eq!(back.n_rows(), 2);
+    assert_eq!(back.cols[0].field.name, "a");
+}
+
+#[test]
+fn test_try_from_polars_returns_ok() {
+    let fa = fa_u32!("u", 5, 6, 7);
+    let s = fa.to_polars();
+    let back = minarrow::Array::try_from_polars(&s).unwrap();
+    assert_eq!(back.len(), 3);
+}
+
+#[cfg(feature = "chunked")]
+#[test]
+fn test_super_array_from_polars_chunked() {
+    use minarrow::SuperArray;
+    let fa1 = fa_i32!("a", 1, 2, 3);
+    let fa2 = fa_i32!("a", 4, 5);
+    let sa_original = SuperArray::from_field_array_chunks(vec![fa1, fa2]);
+
+    let s = sa_original.to_polars();
+    // Polars Series should carry 2 chunks
+    assert_eq!(s.name().as_str(), "a");
+
+    let back = SuperArray::from_polars(&s);
+    assert_eq!(back.len(), 5);
+    assert_eq!(back.field_ref().name, "a");
+}
+
+#[cfg(feature = "chunked")]
+#[test]
+fn test_super_table_from_polars_round_trip() {
+    use minarrow::SuperTable;
+    use std::sync::Arc;
+    let c1 = fa_i32!("a", 1, 2);
+    let c2 = fa_str32!("b", "x", "y");
+    let table1 = Table::new("".into(), Some(vec![c1.clone(), c2.clone()]));
+    let table2 = Table::new("".into(), Some(vec![c1, c2]));
+    let st = SuperTable::from_batches(vec![Arc::new(table1), Arc::new(table2)], None);
+
+    let df = st.to_polars();
+    let back = SuperTable::from_polars(&df);
+
+    assert_eq!(back.n_rows(), 4);
+    assert_eq!(back.n_cols(), 2);
 }


### PR DESCRIPTION
  Mirrors the existing to_* API across Array, FieldArray, Table, SuperArray,
  and SuperTable. Each panicking method has a try_* sibling returning
  Result<_, MinarrowError>. Adds From<&Series>, From<&RecordBatch>,
  From<&DataFrame> for .into() ergonomics.

  New MinarrowError::BridgeError variant carries arrow-rs / polars FFI
  failures, with feature-gated From impls for ArrowError and PolarsError.

  Breaking changes:
    - Removes Array::to_apache_arrow_with_field and Array::to_polars_with_field. Wrap in FieldArray and call its to_*() method when an explicit Field is needed.
    - Renames SuperArray::to_apache_arrow_chunks and SuperTable::to_apache_arrow_batches to to_apache_arrow for symmetry across the bridge API. Return types disambiguate the shape.

  Also fixes a per-call Box leak in the existing to_* paths where the
  ArrowArray/ArrowSchema heap wrappers were not freed after read().

  Closes #65