### PR TITLE
Add exhaustive round-trip tests for arrow-rs and polars bridges

### DIFF
--- a/src/ffi/arrow_rs.rs
+++ b/src/ffi/arrow_rs.rs
@@ -24,6 +24,22 @@
 //! chunked equivalents).
 //!
 //! Gated by the `cast_arrow` feature.
+//!
+//! ## arrow-rs round-trip behaviour
+//!
+//! arrow-rs preserves the Arrow C Data Interface format string verbatim, so
+//! every tested logical type round-trips with dtype and payload bytes
+//! unchanged: `Int8/16/32/64`, `UInt8/16/32/64`, `Float32/64`, `Boolean`,
+//! `String` / `LargeString`, `Dictionary` (categorical), `Date32`, `Date64`,
+//! `Time32(Seconds | Milliseconds)`, `Time64(Microseconds | Nanoseconds)`,
+//! `Timestamp` (all four units with and without a timezone), `Duration32`,
+//! and `Duration64`.
+//!
+//! ## Null masks
+//!
+//! Null bitmaps are part of the C Data Interface buffer set and travel
+//! through this bridge unchanged in both directions. Null counts and bit
+//! positions round-trip exactly.
 
 use std::sync::Arc;
 

--- a/src/ffi/polars.rs
+++ b/src/ffi/polars.rs
@@ -29,6 +29,38 @@
 //! and their `from_*` siblings (and the `Super*` chunked equivalents).
 //!
 //! Gated by the `cast_polars` feature.
+//!
+//! ## Polars round-trip behaviour
+//!
+//! Most Arrow logical types pass through polars unchanged. A few logical types
+//! are normalised by polars's internal representation on the way through. These
+//! conversions are **lossless** - the same logical value is preserved, null
+//! mask survives, and dtype/payload are rescaled together - but the type
+//! label and byte payload differ on the return trip. Each is covered by
+//! a dedicated round-trip test that asserts the promotion explicitly so any
+//! future polars behaviour change surfaces immediately.
+//!
+//! | Sent into polars                    | Returned from polars                | Notes                                              |
+//! |-------------------------------------|--------------------------------------|----------------------------------------------------|
+//! | `Date64` (i64 ms-since-epoch)       | `Timestamp(Milliseconds, None)`     | Payload byte-identical (same i64 ms).              |
+//! | `Time32(Seconds)` (i32)             | `Time64(Nanoseconds)` (i64)         | Payload rescaled: `n * 1_000_000_000`.             |
+//! | `Time32(Milliseconds)` (i32)        | `Time64(Nanoseconds)` (i64)         | Payload rescaled: `n * 1_000_000`.                 |
+//! | `Time64(Microseconds)` (i64)        | `Time64(Nanoseconds)` (i64)         | Payload rescaled: `n * 1_000`.                     |
+//! | `String` / `LargeString` (utf8)     | may return as the other offset width| Polars normalises to its preferred offset width;   |
+//! |                                     |                                     | bytes/text content preserved.                      |
+//!
+//! All other tested logical types - `Int8/16/32/64`, `UInt8/16/32/64`,
+//! `Float32/64`, `Boolean`, `Date32`, `Time64(Nanoseconds)`, all `Timestamp`
+//! units with and without a timezone, `Duration32`, `Duration64`, and
+//! `Dictionary` (categorical) - return with their dtype and payload bytes
+//! unchanged.
+//!
+//! ## Null masks
+//!
+//! Polars preserves the null mask in every direction we test, including
+//! across the type promotions above. Validity bits sit on the underlying
+//! Arrow array and travel through `Series::to_arrow` / `Series::from_arrow`
+//! along with the data buffer.
 
 use std::sync::Arc;
 

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -26,12 +26,35 @@ use arrow::datatypes::{DataType as ADataType, TimeUnit as ATimeUnit};
 use arrow::record_batch::RecordBatch;
 
 use minarrow::{
-    fa_i32, fa_str32, fa_u32, Array as MArray, ArrowType, Field, FieldArray, NumericArray, Table,
-    TextArray,
+    fa_i32, fa_str32, fa_u32, Array as MArray, ArrowType, Field, FieldArray, MaskedArray,
+    NumericArray, Table, TextArray,
 };
 
 #[cfg(feature = "datetime")]
 use minarrow::{TemporalArray, TimeUnit};
+
+// ----- helpers -----
+
+/// Round-trip an `Array` through arrow-rs at the bare-Array level and assert
+/// data equality. Discards Field metadata.
+#[track_caller]
+fn round_trip_array(a: MArray, name: &str) {
+    let ar = a.to_apache_arrow(name);
+    let back = MArray::from_apache_arrow(&ar);
+    assert_eq!(a, back, "Array round-trip mismatch for '{}'", name);
+}
+
+/// Round-trip a `FieldArray` through arrow-rs preserving Field metadata.
+#[track_caller]
+fn round_trip_field_array(fa: FieldArray) {
+    let name = fa.field.name.clone();
+    let dtype = fa.field.dtype.clone();
+    let ar = fa.to_apache_arrow();
+    let back = FieldArray::from_apache_arrow(&name, &ar);
+    assert_eq!(back.field.name, name, "name lost");
+    assert_eq!(back.field.dtype, dtype, "dtype lost");
+    assert_eq!(back.array, fa.array, "data mismatch for '{}'", name);
+}
 
 // -------------------------------
 // Array -> Arrow (numeric)
@@ -370,4 +393,413 @@ fn test_table_to_arrow_record_batch() {
     assert_eq!(a.value(1), 2);
     assert_eq!(b.value(0), "x");
     assert_eq!(b.value(1), "y");
+}
+
+// =============================================================
+// Exhaustive type coverage round-trip
+// =============================================================
+
+#[test]
+fn rt_arrow_i32() {
+    round_trip_array(arr_i32_like(&[1, -2, 3, i32::MAX, i32::MIN]), "i32");
+}
+
+#[test]
+fn rt_arrow_i64() {
+    let mut a = minarrow::IntegerArray::<i64>::default();
+    for v in &[1i64, -2, 3, i64::MAX, i64::MIN] { a.push(*v); }
+    round_trip_array(MArray::from_int64(a), "i64");
+}
+
+#[test]
+fn rt_arrow_u32() {
+    let mut a = minarrow::IntegerArray::<u32>::default();
+    for v in &[0u32, 1, u32::MAX] { a.push(*v); }
+    round_trip_array(MArray::from_uint32(a), "u32");
+}
+
+#[test]
+fn rt_arrow_u64() {
+    let mut a = minarrow::IntegerArray::<u64>::default();
+    for v in &[0u64, 1, u64::MAX] { a.push(*v); }
+    round_trip_array(MArray::from_uint64(a), "u64");
+}
+
+#[test]
+fn rt_arrow_f32() {
+    let mut a = minarrow::FloatArray::<f32>::default();
+    for v in &[0.0_f32, -1.5, 3.14, f32::INFINITY, f32::MIN, f32::MAX] { a.push(*v); }
+    round_trip_array(MArray::from_float32(a), "f32");
+}
+
+#[test]
+fn rt_arrow_f64() {
+    let mut a = minarrow::FloatArray::<f64>::default();
+    for v in &[0.0_f64, -1.5, 3.14, f64::INFINITY, f64::MIN, f64::MAX] { a.push(*v); }
+    round_trip_array(MArray::from_float64(a), "f64");
+}
+
+#[test]
+fn rt_arrow_bool() {
+    let mut a = minarrow::BooleanArray::<()>::default();
+    for v in &[true, false, true, true, false] { a.push(*v); }
+    round_trip_array(MArray::BooleanArray(std::sync::Arc::new(a)), "bool");
+}
+
+#[test]
+fn rt_arrow_string32() {
+    let arr = std::sync::Arc::new(
+        minarrow::StringArray::<u32>::from_slice(&["alpha", "beta", "gamma", ""])
+    );
+    round_trip_array(MArray::TextArray(TextArray::String32(arr)), "string32");
+}
+
+#[cfg(feature = "large_string")]
+#[test]
+fn rt_arrow_string64() {
+    let arr = std::sync::Arc::new(
+        minarrow::StringArray::<u64>::from_slice(&["one", "two", "three"])
+    );
+    round_trip_array(MArray::TextArray(TextArray::String64(arr)), "string64");
+}
+
+#[cfg(any(not(feature = "default_categorical_8"), feature = "extended_categorical"))]
+#[test]
+fn rt_arrow_categorical32() {
+    let arr = std::sync::Arc::new(minarrow::CategoricalArray::<u32>::from_slices(
+        &[0u32, 1, 2, 0, 1],
+        &["red".to_string(), "green".to_string(), "blue".to_string()],
+    ));
+    round_trip_array(MArray::TextArray(TextArray::Categorical32(arr)), "cat32");
+}
+
+// ----- Datetime logical types (via FieldArray) -----
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_date32() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime32(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i32> {
+            data: minarrow::Buffer::from_slice(&[18000, 18500, 19000]),
+            null_mask: None,
+            time_unit: TimeUnit::Days,
+        },
+    )));
+    let fa = FieldArray::new(Field::new("d32", ArrowType::Date32, false, None), a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_date64() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_i64, 1_700_000_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Milliseconds,
+        },
+    )));
+    let fa = FieldArray::new(Field::new("d64", ArrowType::Date64, false, None), a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_time32_sec() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime32(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i32> {
+            data: minarrow::Buffer::from_slice(&[0_i32, 3600, 86399]),
+            null_mask: None,
+            time_unit: TimeUnit::Seconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("t32s", ArrowType::Time32(TimeUnit::Seconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_time32_ms() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime32(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i32> {
+            data: minarrow::Buffer::from_slice(&[0_i32, 1000, 86_399_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Milliseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("t32m", ArrowType::Time32(TimeUnit::Milliseconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_time64_us() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[0_i64, 1_000_000, 86_399_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Microseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("t64u", ArrowType::Time64(TimeUnit::Microseconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_time64_ns() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[0_i64, 1_000_000_000, 86_399_000_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("t64n", ArrowType::Time64(TimeUnit::Nanoseconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_timestamp_s() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_i64, 1_700_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Seconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("ts_s", ArrowType::Timestamp(TimeUnit::Seconds, None), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_timestamp_ms() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_i64]),
+            null_mask: None,
+            time_unit: TimeUnit::Milliseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("ts_ms", ArrowType::Timestamp(TimeUnit::Milliseconds, None), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_timestamp_us() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_000_i64]),
+            null_mask: None,
+            time_unit: TimeUnit::Microseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("ts_us", ArrowType::Timestamp(TimeUnit::Microseconds, None), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_timestamp_ns_with_tz() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_000_000_i64]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new(
+            "ts_ns_utc",
+            ArrowType::Timestamp(TimeUnit::Nanoseconds, Some("UTC".to_string())),
+            false,
+            None,
+        ),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_duration32_sec() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime32(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i32> {
+            data: minarrow::Buffer::from_slice(&[10_i32, 20, 30]),
+            null_mask: None,
+            time_unit: TimeUnit::Seconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("dur32s", ArrowType::Duration32(TimeUnit::Seconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_arrow_duration64_ns() {
+    let a = MArray::TemporalArray(TemporalArray::Datetime64(std::sync::Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_000_000_i64, 2_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("dur64n", ArrowType::Duration64(TimeUnit::Nanoseconds), false, None),
+        a,
+    );
+    round_trip_field_array(fa);
+}
+
+// ----- Nullability -----
+
+#[test]
+fn rt_arrow_i32_with_nulls() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    a.push(1);
+    a.push_null();
+    a.push(3);
+    a.push_null();
+    a.push(5);
+    round_trip_array(MArray::from_int32(a), "i32_nulls");
+}
+
+#[test]
+fn rt_arrow_f64_with_nulls() {
+    let mut a = minarrow::FloatArray::<f64>::default();
+    a.push(1.5);
+    a.push_null();
+    a.push(2.5);
+    round_trip_array(MArray::from_float64(a), "f64_nulls");
+}
+
+#[test]
+fn rt_arrow_bool_with_nulls() {
+    let mut a = minarrow::BooleanArray::<()>::default();
+    a.push(true);
+    a.push_null();
+    a.push(false);
+    a.push_null();
+    a.push(true);
+    round_trip_array(MArray::BooleanArray(std::sync::Arc::new(a)), "bool_nulls");
+}
+
+#[test]
+fn rt_arrow_string_with_nulls() {
+    let mut a = minarrow::StringArray::<u32>::default();
+    a.push_str("foo");
+    a.push_null();
+    a.push_str("bar");
+    a.push_null();
+    a.push_str("");
+    round_trip_array(MArray::from_string32(a), "string_nulls");
+}
+
+#[test]
+fn rt_arrow_i32_all_null() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    for _ in 0..5 { a.push_null(); }
+    round_trip_array(MArray::from_int32(a), "i32_all_null");
+}
+
+#[test]
+fn rt_arrow_string_all_null() {
+    let mut a = minarrow::StringArray::<u32>::default();
+    for _ in 0..3 { a.push_null(); }
+    round_trip_array(MArray::from_string32(a), "string_all_null");
+}
+
+// ----- Empty arrays -----
+
+#[test]
+fn rt_arrow_empty_i32() {
+    round_trip_array(MArray::from_int32(minarrow::IntegerArray::<i32>::default()), "empty_i32");
+}
+
+#[test]
+fn rt_arrow_empty_f64() {
+    round_trip_array(MArray::from_float64(minarrow::FloatArray::<f64>::default()), "empty_f64");
+}
+
+#[test]
+fn rt_arrow_empty_bool() {
+    round_trip_array(
+        MArray::BooleanArray(std::sync::Arc::new(minarrow::BooleanArray::<()>::default())),
+        "empty_bool",
+    );
+}
+
+#[test]
+fn rt_arrow_empty_string() {
+    round_trip_array(MArray::from_string32(minarrow::StringArray::<u32>::default()), "empty_string");
+}
+
+// ----- Single-element -----
+
+#[test]
+fn rt_arrow_single_element_i32() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    a.push(42);
+    round_trip_array(MArray::from_int32(a), "single_i32");
+}
+
+#[test]
+fn rt_arrow_single_element_string() {
+    let arr = std::sync::Arc::new(minarrow::StringArray::<u32>::from_slice(&["solo"]));
+    round_trip_array(MArray::TextArray(TextArray::String32(arr)), "single_str");
+}
+
+// ----- Empty chunked containers -----
+
+#[cfg(feature = "chunked")]
+#[test]
+fn rt_arrow_empty_super_array() {
+    let sa = minarrow::SuperArray::new();
+    let chunks = sa.to_apache_arrow();
+    assert_eq!(chunks.len(), 0);
+}
+
+#[cfg(feature = "chunked")]
+#[test]
+fn rt_arrow_empty_super_table() {
+    let st = minarrow::SuperTable::new("".into());
+    let rbs = st.to_apache_arrow();
+    assert_eq!(rbs.len(), 0);
+    let back = minarrow::SuperTable::from_apache_arrow(&rbs);
+    assert_eq!(back.n_batches(), 0);
+}
+
+// ----- helpers -----
+
+fn arr_i32_like(vals: &[i32]) -> MArray {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    for v in vals { a.push(*v); }
+    MArray::from_int32(a)
 }

--- a/tests/polars.rs
+++ b/tests/polars.rs
@@ -19,11 +19,40 @@
 use std::sync::Arc;
 
 use minarrow::{
-    fa_i32, fa_str32, fa_u32, Array, ArrowType, Field, MaskedArray, NumericArray, Table, TextArray,
+    fa_i32, fa_str32, fa_u32, Array, ArrowType, Field, FieldArray, MaskedArray, NumericArray,
+    Table, TextArray,
 };
 #[cfg(feature = "datetime")]
 use minarrow::{TemporalArray, TimeUnit};
 use polars::prelude::*;
+
+// ----- helpers -----
+
+/// Round-trip a bare `Array` through polars at the bare-Array level.
+#[track_caller]
+fn round_trip_array_polars(a: Array, name: &str) {
+    let s = a.to_polars(name);
+    let back = Array::from_polars(&s);
+    assert_eq!(a, back, "Array round-trip mismatch for '{}'", name);
+}
+
+/// Round-trip a `FieldArray` through polars and assert STRICT fidelity:
+/// name, dtype, and data all survive unchanged.
+///
+/// Use this helper only for dtypes that polars passes through identically.
+/// For dtypes where polars remaps the logical type (e.g. Date64 -> Timestamp
+/// (Milliseconds, None)) write the test inline and assert the expected
+/// promoted dtype + data equality explicitly so the remap is documented.
+#[track_caller]
+fn round_trip_field_array_polars(fa: FieldArray) {
+    let name = fa.field.name.clone();
+    let dtype = fa.field.dtype.clone();
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+    assert_eq!(back.field.name, name, "name lost");
+    assert_eq!(back.field.dtype, dtype, "dtype lost");
+    assert_eq!(back.array, fa.array, "data mismatch for '{}'", name);
+}
 
 #[test]
 fn test_array_to_polars_numeric() {
@@ -273,4 +302,545 @@ fn test_super_table_from_polars_round_trip() {
 
     assert_eq!(back.n_rows(), 4);
     assert_eq!(back.n_cols(), 2);
+}
+
+// =============================================================
+// Exhaustive type coverage round-trip (polars side)
+// =============================================================
+//
+// Polars upcasts some types on round-trip (e.g. String32 -> LargeUtf8 / String64).
+// Where the data layout survives but the offset width may flip, we compare
+// element-wise to be width-agnostic.
+
+fn arr_strings_back(back: &Array) -> Vec<String> {
+    match back {
+        Array::TextArray(TextArray::String32(b)) => (0..b.len())
+            .map(|i| b.get_str(i).unwrap_or("").to_string())
+            .collect(),
+        Array::TextArray(TextArray::String64(b)) => (0..b.len())
+            .map(|i| b.get_str(i).unwrap_or("").to_string())
+            .collect(),
+        _ => panic!("expected string array, got {:?}", back),
+    }
+}
+
+#[test]
+fn rt_polars_i32() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    for v in &[1i32, -2, 3, i32::MAX, i32::MIN] { a.push(*v); }
+    round_trip_array_polars(Array::from_int32(a), "i32");
+}
+
+#[test]
+fn rt_polars_i64() {
+    let mut a = minarrow::IntegerArray::<i64>::default();
+    for v in &[1i64, -2, 3, i64::MAX, i64::MIN] { a.push(*v); }
+    round_trip_array_polars(Array::from_int64(a), "i64");
+}
+
+#[test]
+fn rt_polars_u32() {
+    let mut a = minarrow::IntegerArray::<u32>::default();
+    for v in &[0u32, 1, u32::MAX] { a.push(*v); }
+    round_trip_array_polars(Array::from_uint32(a), "u32");
+}
+
+#[test]
+fn rt_polars_u64() {
+    let mut a = minarrow::IntegerArray::<u64>::default();
+    for v in &[0u64, 1, u64::MAX] { a.push(*v); }
+    round_trip_array_polars(Array::from_uint64(a), "u64");
+}
+
+#[test]
+fn rt_polars_f32() {
+    let mut a = minarrow::FloatArray::<f32>::default();
+    for v in &[0.0_f32, -1.5, 3.14, f32::MIN, f32::MAX] { a.push(*v); }
+    round_trip_array_polars(Array::from_float32(a), "f32");
+}
+
+#[test]
+fn rt_polars_f64() {
+    let mut a = minarrow::FloatArray::<f64>::default();
+    for v in &[0.0_f64, -1.5, 3.14, f64::MIN, f64::MAX] { a.push(*v); }
+    round_trip_array_polars(Array::from_float64(a), "f64");
+}
+
+#[test]
+fn rt_polars_bool() {
+    let mut a = minarrow::BooleanArray::<()>::default();
+    for v in &[true, false, true, true, false] { a.push(*v); }
+    round_trip_array_polars(Array::BooleanArray(Arc::new(a)), "bool");
+}
+
+#[test]
+fn rt_polars_string32_element_equal() {
+    // Polars may upcast Utf8 -> LargeUtf8; check element-wise.
+    let arr = Arc::new(
+        minarrow::StringArray::<u32>::from_slice(&["alpha", "beta", "gamma"])
+    );
+    let original = Array::TextArray(TextArray::String32(arr));
+    let s = original.to_polars("s");
+    let back = Array::from_polars(&s);
+    assert_eq!(
+        arr_strings_back(&back),
+        vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
+    );
+}
+
+#[cfg(feature = "large_string")]
+#[test]
+fn rt_polars_string64_element_equal() {
+    let arr = Arc::new(
+        minarrow::StringArray::<u64>::from_slice(&["one", "two", "three"])
+    );
+    let original = Array::TextArray(TextArray::String64(arr));
+    let s = original.to_polars("s");
+    let back = Array::from_polars(&s);
+    assert_eq!(
+        arr_strings_back(&back),
+        vec!["one".to_string(), "two".to_string(), "three".to_string()]
+    );
+}
+
+#[cfg(any(not(feature = "default_categorical_8"), feature = "extended_categorical"))]
+#[test]
+fn rt_polars_categorical32_element_equal() {
+    let arr = Arc::new(minarrow::CategoricalArray::<u32>::from_slices(
+        &[0u32, 1, 2, 0, 1],
+        &["red".to_string(), "green".to_string(), "blue".to_string()],
+    ));
+    let original = Array::TextArray(TextArray::Categorical32(arr));
+    let s = original.to_polars("cat");
+    let back = Array::from_polars(&s);
+    // Polars Categorical may come back as either Categorical or as a string
+    // type depending on CompatLevel and version; compare values either way.
+    let back_strings: Vec<String> = match &back {
+        Array::TextArray(TextArray::Categorical32(c)) => (0..c.data.len())
+            .map(|i| c.unique_values[c.data[i] as usize].clone())
+            .collect(),
+        Array::TextArray(_) => arr_strings_back(&back),
+        _ => panic!("unexpected back type: {:?}", back),
+    };
+    assert_eq!(
+        back_strings,
+        vec!["red", "green", "blue", "red", "green"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ----- Datetime logical types (via FieldArray) -----
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_date32() {
+    let a = Array::TemporalArray(TemporalArray::Datetime32(Arc::new(
+        minarrow::DatetimeArray::<i32> {
+            data: minarrow::Buffer::from_slice(&[18000_i32, 18500, 19000]),
+            null_mask: None,
+            time_unit: TimeUnit::Days,
+        },
+    )));
+    let fa = FieldArray::new(Field::new("d32", ArrowType::Date32, false, None), a);
+    round_trip_field_array_polars(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_date64_promotes_to_timestamp_ms() {
+    // Polars remaps Date64 (ms-since-epoch i64) to Timestamp(Milliseconds, None)
+    // internally. This is not lossy: the i64 ms-since-epoch payload is byte-identical;
+    // only the logical type label changes. We assert both halves explicitly so a
+    // future polars behaviour change (or one of our own bugs) surfaces immediately.
+    let original_data = [1_600_000_000_000_i64, 1_700_000_000_000];
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&original_data),
+            null_mask: None,
+            time_unit: TimeUnit::Milliseconds,
+        },
+    )));
+    let fa = FieldArray::new(Field::new("d64", ArrowType::Date64, false, None), a.clone());
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.name, "d64", "name lost");
+    assert_eq!(
+        back.field.dtype,
+        ArrowType::Timestamp(TimeUnit::Milliseconds, None),
+        "polars is expected to promote Date64 -> Timestamp(Milliseconds, None); if this changes, the remap layer needs updating"
+    );
+
+    // The physical i64 ms-since-epoch payload must be identical (lossless promotion).
+    match (&a, &back.array) {
+        (
+            Array::TemporalArray(TemporalArray::Datetime64(lhs)),
+            Array::TemporalArray(TemporalArray::Datetime64(rhs)),
+        ) => {
+            assert_eq!(rhs.time_unit, TimeUnit::Milliseconds, "time_unit drifted");
+            assert_eq!(&rhs.data[..], &original_data[..], "i64 ms payload changed");
+            assert_eq!(lhs.null_mask, rhs.null_mask, "null mask changed");
+        }
+        other => panic!("expected Datetime64 on both sides, got {:?}", other),
+    }
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_timestamp_ns() {
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_000_000_i64]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("ts_ns", ArrowType::Timestamp(TimeUnit::Nanoseconds, None), false, None),
+        a,
+    );
+    round_trip_field_array_polars(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_timestamp_us() {
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_600_000_000_000_000_i64]),
+            null_mask: None,
+            time_unit: TimeUnit::Microseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("ts_us", ArrowType::Timestamp(TimeUnit::Microseconds, None), false, None),
+        a,
+    );
+    round_trip_field_array_polars(fa);
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_duration_ns() {
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+        minarrow::DatetimeArray::<i64> {
+            data: minarrow::Buffer::from_slice(&[1_000_000_i64, 2_000_000]),
+            null_mask: None,
+            time_unit: TimeUnit::Nanoseconds,
+        },
+    )));
+    let fa = FieldArray::new(
+        Field::new("dur_ns", ArrowType::Duration64(TimeUnit::Nanoseconds), false, None),
+        a,
+    );
+    round_trip_field_array_polars(fa);
+}
+
+// ----- Nullability -----
+
+#[test]
+fn rt_polars_i32_with_nulls() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    a.push(1);
+    a.push_null();
+    a.push(3);
+    a.push_null();
+    a.push(5);
+    round_trip_array_polars(Array::from_int32(a), "i32_nulls");
+}
+
+#[test]
+fn rt_polars_f64_with_nulls() {
+    let mut a = minarrow::FloatArray::<f64>::default();
+    a.push(1.5);
+    a.push_null();
+    a.push(2.5);
+    round_trip_array_polars(Array::from_float64(a), "f64_nulls");
+}
+
+#[test]
+fn rt_polars_bool_with_nulls() {
+    let mut a = minarrow::BooleanArray::<()>::default();
+    a.push(true);
+    a.push_null();
+    a.push(false);
+    a.push_null();
+    a.push(true);
+    round_trip_array_polars(Array::BooleanArray(Arc::new(a)), "bool_nulls");
+}
+
+#[test]
+fn rt_polars_i32_all_null() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    for _ in 0..5 { a.push_null(); }
+    round_trip_array_polars(Array::from_int32(a), "i32_all_null");
+}
+
+// ----- Empty arrays -----
+
+#[test]
+fn rt_polars_empty_i32() {
+    round_trip_array_polars(
+        Array::from_int32(minarrow::IntegerArray::<i32>::default()),
+        "empty_i32",
+    );
+}
+
+#[test]
+fn rt_polars_empty_f64() {
+    round_trip_array_polars(
+        Array::from_float64(minarrow::FloatArray::<f64>::default()),
+        "empty_f64",
+    );
+}
+
+#[test]
+fn rt_polars_empty_bool() {
+    round_trip_array_polars(
+        Array::BooleanArray(Arc::new(minarrow::BooleanArray::<()>::default())),
+        "empty_bool",
+    );
+}
+
+// ----- Single-element -----
+
+#[test]
+fn rt_polars_single_element_i32() {
+    let mut a = minarrow::IntegerArray::<i32>::default();
+    a.push(42);
+    round_trip_array_polars(Array::from_int32(a), "single_i32");
+}
+
+// ----- Empty chunked containers -----
+
+#[cfg(feature = "chunked")]
+#[test]
+fn rt_polars_empty_super_table() {
+    let st = minarrow::SuperTable::new("".into());
+    let df = st.to_polars();
+    assert_eq!(df.height(), 0);
+    assert_eq!(df.width(), 0);
+    let back = minarrow::SuperTable::from_polars(&df);
+    assert_eq!(back.n_batches(), 0);
+}
+
+// ----- Time32 / Time64 polars round-trip (real round-trip, not just export) -----
+
+// ----- Time32 / Time64 polars round-trip -----
+//
+// Polars normalises ALL Time* logical types to `Time64(Nanoseconds)` internally
+// and rescales the underlying integer payload accordingly. The promotion is
+// lossless (same time-of-day, larger physical type with finer resolution) but
+// the byte representation changes:
+//   Time32(Sec)   [n]  -> Time64(Ns)  [n * 1_000_000_000]
+//   Time32(Ms)    [n]  -> Time64(Ns)  [n * 1_000_000]
+//   Time64(Us)    [n]  -> Time64(Ns)  [n * 1_000]
+//   Time64(Ns)    [n]  -> Time64(Ns)  [n]            (pass-through)
+//
+// Tests assert both the dtype promotion and the rescaled payload explicitly.
+
+#[cfg(feature = "datetime")]
+fn assert_time_promotes_to_ns_i64(
+    fa: FieldArray,
+    name: &str,
+    expected_ns: &[i64],
+) {
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+    assert_eq!(back.field.name, name, "name lost");
+    assert_eq!(
+        back.field.dtype,
+        ArrowType::Time64(TimeUnit::Nanoseconds),
+        "polars is expected to promote all Time* to Time64(Nanoseconds)"
+    );
+    match &back.array {
+        Array::TemporalArray(TemporalArray::Datetime64(d)) => {
+            assert_eq!(d.time_unit, TimeUnit::Nanoseconds, "time_unit drifted");
+            assert_eq!(&d.data[..], expected_ns, "rescaled ns payload mismatch");
+            assert!(d.null_mask.is_none(), "no nulls expected");
+        }
+        other => panic!("expected Datetime64, got {:?}", other),
+    }
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time32_sec_promotes_to_time64_ns() {
+    let fa = FieldArray::new(
+        Field::new("t32s", ArrowType::Time32(TimeUnit::Seconds), false, None),
+        Array::TemporalArray(TemporalArray::Datetime32(Arc::new(
+            minarrow::DatetimeArray::<i32> {
+                data: minarrow::Buffer::from_slice(&[0_i32, 3600, 86399]),
+                null_mask: None,
+                time_unit: TimeUnit::Seconds,
+            },
+        ))),
+    );
+    assert_time_promotes_to_ns_i64(
+        fa,
+        "t32s",
+        &[0, 3_600_000_000_000, 86_399_000_000_000],
+    );
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time32_ms_promotes_to_time64_ns() {
+    let fa = FieldArray::new(
+        Field::new("t32m", ArrowType::Time32(TimeUnit::Milliseconds), false, None),
+        Array::TemporalArray(TemporalArray::Datetime32(Arc::new(
+            minarrow::DatetimeArray::<i32> {
+                data: minarrow::Buffer::from_slice(&[0_i32, 1000, 86_399_000]),
+                null_mask: None,
+                time_unit: TimeUnit::Milliseconds,
+            },
+        ))),
+    );
+    assert_time_promotes_to_ns_i64(
+        fa,
+        "t32m",
+        &[0, 1_000_000_000, 86_399_000_000_000],
+    );
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time64_us_promotes_to_time64_ns() {
+    let fa = FieldArray::new(
+        Field::new("t64u", ArrowType::Time64(TimeUnit::Microseconds), false, None),
+        Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+            minarrow::DatetimeArray::<i64> {
+                data: minarrow::Buffer::from_slice(&[0_i64, 1_000_000, 86_399_000_000]),
+                null_mask: None,
+                time_unit: TimeUnit::Microseconds,
+            },
+        ))),
+    );
+    assert_time_promotes_to_ns_i64(
+        fa,
+        "t64u",
+        &[0, 1_000_000_000, 86_399_000_000_000],
+    );
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time64_ns() {
+    // Time64(Ns) is the polars-native representation; passes through unchanged.
+    let fa = FieldArray::new(
+        Field::new("t64n", ArrowType::Time64(TimeUnit::Nanoseconds), false, None),
+        Array::TemporalArray(TemporalArray::Datetime64(Arc::new(
+            minarrow::DatetimeArray::<i64> {
+                data: minarrow::Buffer::from_slice(&[0_i64, 1_000_000_000, 86_399_000_000_000]),
+                null_mask: None,
+                time_unit: TimeUnit::Nanoseconds,
+            },
+        ))),
+    );
+    round_trip_field_array_polars(fa);
+}
+
+// ----- Null-mask preservation under polars logical-type promotion -----
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_date64_preserves_null_mask_through_timestamp_promotion() {
+    // Build a Date64 with a null in the middle, send through polars (which
+    // promotes to Timestamp(Ms, None)), and assert the null position survives.
+    let mut data = minarrow::DatetimeArray::<i64> {
+        data: minarrow::Buffer::from_slice(&[1_600_000_000_000_i64, 0, 1_700_000_000_000]),
+        null_mask: None,
+        time_unit: TimeUnit::Milliseconds,
+    };
+    // Mark index 1 as null
+    let mut mask = minarrow::Bitmask::new_set_all(3, true);
+    unsafe { mask.set_unchecked(1, false) };
+    data.null_mask = Some(mask);
+
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(data)));
+    let fa = FieldArray::new(Field::new("d64n", ArrowType::Date64, true, None), a);
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.dtype, ArrowType::Timestamp(TimeUnit::Milliseconds, None));
+    match &back.array {
+        Array::TemporalArray(TemporalArray::Datetime64(d)) => {
+            let mask = d.null_mask.as_ref().expect("null mask must survive promotion");
+            assert!(unsafe { mask.get_unchecked(0) }, "idx 0 should be valid");
+            assert!(!unsafe { mask.get_unchecked(1) }, "idx 1 should be null");
+            assert!(unsafe { mask.get_unchecked(2) }, "idx 2 should be valid");
+        }
+        other => panic!("expected Datetime64, got {:?}", other),
+    }
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time32_sec_preserves_null_mask_through_promotion() {
+    // Time32(Sec) with a null, promoted to Time64(Ns) by polars.
+    let mut data = minarrow::DatetimeArray::<i32> {
+        data: minarrow::Buffer::from_slice(&[0_i32, 0, 3600]),
+        null_mask: None,
+        time_unit: TimeUnit::Seconds,
+    };
+    let mut mask = minarrow::Bitmask::new_set_all(3, true);
+    unsafe { mask.set_unchecked(1, false) };
+    data.null_mask = Some(mask);
+
+    let a = Array::TemporalArray(TemporalArray::Datetime32(Arc::new(data)));
+    let fa = FieldArray::new(
+        Field::new("t32sn", ArrowType::Time32(TimeUnit::Seconds), true, None),
+        a,
+    );
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.dtype, ArrowType::Time64(TimeUnit::Nanoseconds));
+    match &back.array {
+        Array::TemporalArray(TemporalArray::Datetime64(d)) => {
+            let mask = d.null_mask.as_ref().expect("null mask must survive promotion");
+            assert!(unsafe { mask.get_unchecked(0) }, "idx 0 should be valid");
+            assert!(!unsafe { mask.get_unchecked(1) }, "idx 1 should be null");
+            assert!(unsafe { mask.get_unchecked(2) }, "idx 2 should be valid");
+            // Valid positions rescaled: 0 sec -> 0 ns, 3600 sec -> 3.6e12 ns.
+            assert_eq!(d.data[0], 0);
+            assert_eq!(d.data[2], 3_600_000_000_000);
+        }
+        other => panic!("expected Datetime64, got {:?}", other),
+    }
+}
+
+#[cfg(feature = "datetime")]
+#[test]
+fn rt_polars_time64_us_preserves_null_mask_through_promotion() {
+    let mut data = minarrow::DatetimeArray::<i64> {
+        data: minarrow::Buffer::from_slice(&[0_i64, 0, 1_000_000]),
+        null_mask: None,
+        time_unit: TimeUnit::Microseconds,
+    };
+    let mut mask = minarrow::Bitmask::new_set_all(3, true);
+    unsafe { mask.set_unchecked(1, false) };
+    data.null_mask = Some(mask);
+
+    let a = Array::TemporalArray(TemporalArray::Datetime64(Arc::new(data)));
+    let fa = FieldArray::new(
+        Field::new("t64un", ArrowType::Time64(TimeUnit::Microseconds), true, None),
+        a,
+    );
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.dtype, ArrowType::Time64(TimeUnit::Nanoseconds));
+    match &back.array {
+        Array::TemporalArray(TemporalArray::Datetime64(d)) => {
+            let mask = d.null_mask.as_ref().expect("null mask must survive promotion");
+            assert!(unsafe { mask.get_unchecked(0) });
+            assert!(!unsafe { mask.get_unchecked(1) });
+            assert!(unsafe { mask.get_unchecked(2) });
+            assert_eq!(d.data[2], 1_000_000_000); // 1_000_000 us -> 1e9 ns
+        }
+        other => panic!("expected Datetime64, got {:?}", other),
+    }
 }


### PR DESCRIPTION
Adds type coverage across every supported logical type plus null-mask, empty, single-element, and chunked edge cases. 60 new tests across tests/apache_arrow.rs and tests/polars.rs:

  - arrow-rs side: i32/i64/u32/u64, f32/f64, bool, String32/String64, Categorical32, Date32, Date64, Time32(Sec|Ms), Time64(Us|Ns), Timestamp(Sec|Ms|Us|Ns) with and without tz, Duration32/64, all asserted strict equality on round-trip.
  - polars side: same coverage, with inline assertions documenting polars's lossless logical-type promotions:
      Date64           -> Timestamp(Milliseconds, None)
      Time32(Sec)      -> Time64(Nanoseconds)   (payload rescaled)
      Time32(Ms)       -> Time64(Nanoseconds)   (payload rescaled)
      Time64(Us)       -> Time64(Nanoseconds)   (payload rescaled)
    Each promotion is covered by a dedicated test that verifies the
    target dtype, the rescaled payload values, and null-mask
    preservation across the promotion.

Documents the current round-trip behaviour of both bridges in their module docs (src/ffi/arrow_rs.rs and src/ffi/polars.rs). The accompanying tests assert this behaviour directly, so any drift in polars or arrow-rs will expose itself as a failing test.