### PR TITLE
Polars ingestion fix.

### DIFF
--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -3026,8 +3026,35 @@ impl Array {
 
     /// Import a Polars `Series` into a Minarrow `Array`.
     ///
-    /// The series name and recovered Field metadata are dropped. Use
-    /// [`crate::FieldArray::from_polars`] to preserve them.
+    /// A polars `Series` is inherently multi-chunked; the canonical mapping
+    /// is `Series` <-> [`crate::SuperArray`]. This helper routes through
+    /// [`crate::SuperArray::from_polars`] and then **consolidates** the
+    /// chunks into a single contiguous, 64-byte aligned buffer. The series
+    /// name and recovered Field metadata are dropped on the way through;
+    /// use [`crate::FieldArray::from_polars`] to preserve them.
+    ///
+    /// ## Performance note
+    /// Two separate costs to be aware of:
+    ///
+    /// 1. **Alignment copy**: Polars data is typically 8-byte aligned (per
+    ///    the Arrow spec default), while Minarrow uses 64-byte aligned
+    ///    `Vec64<T>` buffers for SIMD. Most of the time this results in a
+    ///    memory copy to realign on import, unless the source data happens
+    ///    to be pre-aligned to 64 bytes. The FFI hand-off itself is
+    ///    pointer-level zero-copy; the realignment is done by
+    ///    `Buffer::from_shared` when the source isn't 64-byte aligned.
+    ///
+    /// 2. **Consolidation copy**: Multi-chunk Series are merged into a
+    ///    single contiguous buffer, which is a second O(n) allocation and
+    ///    copy pass. Single-chunk Series (e.g. after `s.rechunk()` on the
+    ///    caller side) skip this step. The consolidation itself is cheap
+    ///    on Linux when the `vmap64` feature is enabled.
+    ///
+    /// In practice you should expect at least one full allocation + copy
+    /// when importing polars data into an `Array`. If you would like to
+    /// preserve the original chunk boundaries and avoid the consolidation
+    /// step, use [`crate::SuperArray::from_polars`] directly - though the
+    /// alignment copy will still occur per chunk that isn't pre-aligned.
     ///
     /// Panics on FFI failure. For a fallible variant, see
     /// [`Array::try_from_polars`].
@@ -3040,8 +3067,9 @@ impl Array {
     /// Fallible variant of [`Array::from_polars`].
     #[cfg(feature = "cast_polars")]
     pub fn try_from_polars(s: &polars::prelude::Series) -> Result<Array, MinarrowError> {
-        let (array_arc, _field) = crate::ffi::polars::import(s)?;
-        Ok(Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone()))
+        use crate::SuperArray;
+        use crate::traits::consolidate::Consolidate;
+        Ok(SuperArray::try_from_polars(s)?.consolidate())
     }
 }
 

--- a/src/ffi/polars.rs
+++ b/src/ffi/polars.rs
@@ -64,7 +64,7 @@
 
 use std::sync::Arc;
 
-use polars::prelude::{CompatLevel, Series};
+use polars::prelude::Series;
 
 use crate::enums::error::MinarrowError;
 use crate::ffi::arrow_c_ffi::{ArrowArray, ArrowSchema, export_to_c, import_from_c_owned};
@@ -110,18 +110,6 @@ pub fn export(
     })?;
 
     Ok(Series::from_arrow(name.into(), a2_array)?)
-}
-
-/// Import a polars `Series` into a Minarrow `(Arc<Array>, Field)`.
-///
-/// Reads chunk 0 of the Series. Callers wanting all chunks should use the
-/// `SuperArray::from_polars` path which iterates over `s.n_chunks()`.
-///
-/// The recovered `Field` has its `name` overridden with `s.name()` so the
-/// Series name round-trips cleanly.
-pub fn import(s: &Series) -> Result<(Arc<Array>, Field), MinarrowError> {
-    let arr2 = s.to_arrow(0, CompatLevel::oldest());
-    import_chunk(s.name().as_str(), s.null_count() > 0, arr2)
 }
 
 /// Import a single polars_arrow `Array` (one chunk) with caller-supplied

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -1229,6 +1229,16 @@ impl SuperArray {
     /// Build a `SuperArray` from a Polars `Series`, preserving the Series'
     /// internal chunk boundaries.
     ///
+    /// ## Performance note
+    /// Polars data is typically 8-byte aligned (per the Arrow spec default),
+    /// while Minarrow uses 64-byte aligned `Vec64<T>` buffers for SIMD.
+    /// Most of the time this results in a memory copy per chunk to realign
+    /// on import, unless the source data happens to be pre-aligned to 64
+    /// bytes. The FFI hand-off itself is pointer-level zero-copy; the
+    /// realignment is done by `Buffer::from_shared` when the source isn't
+    /// 64-byte aligned. No consolidation copy is performed - chunk
+    /// boundaries are preserved as-is.
+    ///
     /// Panics on FFI failure. For a fallible variant, see
     /// [`SuperArray::try_from_polars`].
     #[cfg(feature = "cast_polars")]

--- a/src/structs/chunked/super_table.rs
+++ b/src/structs/chunked/super_table.rs
@@ -1002,6 +1002,16 @@ impl SuperTable {
     /// to batches; if chunks are misaligned across columns we re-chunk the
     /// DataFrame to a single chunk first as a fallback.
     ///
+    /// ## Performance note
+    /// Polars data is typically 8-byte aligned (per the Arrow spec default),
+    /// while Minarrow uses 64-byte aligned `Vec64<T>` buffers for SIMD.
+    /// Most of the time this results in a memory copy per chunk to realign
+    /// on import, unless the source data happens to be pre-aligned to 64
+    /// bytes. The FFI hand-off itself is pointer-level zero-copy; the
+    /// realignment is done by `Buffer::from_shared` when the source isn't
+    /// 64-byte aligned. No consolidation copy is performed unless the
+    /// chunk-misalignment fallback path is taken.
+    ///
     /// Panics on FFI failure. For a fallible variant, see
     /// [`SuperTable::try_from_polars`].
     #[cfg(feature = "cast_polars")]

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -390,8 +390,36 @@ impl FieldArray {
 
     /// Build a `FieldArray` from a Polars `Series`.
     ///
-    /// Name comes from `s.name()`. Dtype, nullability, and any custom metadata
-    /// are recovered from the FFI schema.
+    /// A polars `Series` is inherently multi-chunked; the canonical mapping
+    /// is `Series` <-> [`crate::SuperArray`]. This helper routes through
+    /// [`crate::SuperArray::from_polars`] and then **consolidates** the
+    /// chunks into a single contiguous, 64-byte aligned buffer.
+    ///
+    /// ## Performance note
+    /// Two separate costs to be aware of:
+    ///
+    /// 1. **Alignment copy**: Polars data is typically 8-byte aligned (per
+    ///    the Arrow spec default), while Minarrow uses 64-byte aligned
+    ///    `Vec64<T>` buffers for SIMD. Most of the time this results in a
+    ///    memory copy to realign on import, unless the source data happens
+    ///    to be pre-aligned to 64 bytes. The FFI hand-off itself is
+    ///    pointer-level zero-copy; the realignment is done by
+    ///    `Buffer::from_shared` when the source isn't 64-byte aligned.
+    ///
+    /// 2. **Consolidation copy**: Multi-chunk Series are merged into a
+    ///    single contiguous buffer, which is a second O(n) allocation and
+    ///    copy pass. Single-chunk Series (e.g. after `s.rechunk()` on the
+    ///    caller side) skip this step. The consolidation itself is cheap
+    ///    on Linux when the `vmap64` feature is enabled.
+    ///
+    /// In practice you should expect at least one full allocation + copy
+    /// when importing polars data into a `FieldArray`. If you would like to
+    /// preserve the original chunk boundaries and avoid the consolidation
+    /// step, use [`crate::SuperArray::from_polars`] directly - though the
+    /// alignment copy will still occur per chunk that isn't pre-aligned.
+    ///
+    /// Name comes from `s.name()`; dtype, nullability, and any custom
+    /// metadata are recovered from the FFI schema.
     ///
     /// Panics on FFI failure. For a fallible variant, see
     /// [`FieldArray::try_from_polars`].
@@ -406,8 +434,11 @@ impl FieldArray {
     pub fn try_from_polars(
         s: &polars::prelude::Series,
     ) -> Result<FieldArray, MinarrowError> {
-        let (array_arc, field) = crate::ffi::polars::import(s)?;
-        let array = Arc::try_unwrap(array_arc).unwrap_or_else(|arc| (*arc).clone());
+        use crate::SuperArray;
+        use crate::traits::consolidate::Consolidate;
+        let sa = SuperArray::try_from_polars(s)?;
+        let field = sa.field_ref().clone();
+        let array = sa.consolidate();
         Ok(FieldArray::new(field, array))
     }
 }

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -774,8 +774,41 @@ impl Table {
         Ok(Table::new(String::new(), Some(cols)))
     }
 
-    /// Build a `Table` from a Polars `DataFrame`. Column names, dtypes,
-    /// nullability, and any custom Series metadata are recovered.
+    /// Build a `Table` from a Polars `DataFrame`.
+    ///
+    /// A polars `DataFrame` has columns that are inherently multi-chunked;
+    /// the canonical mapping is `DataFrame` <-> [`crate::SuperTable`]. This
+    /// helper routes through [`crate::SuperTable::from_polars`] and then
+    /// **consolidates** the batches into a single contiguous `Table` with
+    /// 64-byte aligned column buffers.
+    ///
+    /// Column names, dtypes, nullability, and any custom Series metadata
+    /// are recovered.
+    ///
+    /// ## Performance note
+    /// Two separate costs to be aware of:
+    ///
+    /// 1. **Alignment copy**: Polars data is typically 8-byte aligned (per
+    ///    the Arrow spec default), while Minarrow uses 64-byte aligned
+    ///    `Vec64<T>` buffers for SIMD. Most of the time this results in a
+    ///    memory copy to realign on import, unless the source data happens
+    ///    to be pre-aligned to 64 bytes. The FFI hand-off itself is
+    ///    pointer-level zero-copy; the realignment is done by
+    ///    `Buffer::from_shared` when the source isn't 64-byte aligned.
+    ///
+    /// 2. **Consolidation copy**: Multi-chunk columns are merged into a
+    ///    single contiguous buffer per column, which is a second O(n)
+    ///    allocation and copy pass. Single-chunk DataFrames (e.g. after
+    ///    `df.align_chunks_par()` then `df.rechunk()` on the caller side)
+    ///    skip this step. The consolidation itself is cheap on Linux when
+    ///    the `vmap64` feature is enabled.
+    ///
+    /// In practice you should expect at least one full allocation + copy
+    /// when importing a polars DataFrame into a `Table`. If you would like
+    /// to preserve the original chunk boundaries and avoid the
+    /// consolidation step, use [`crate::SuperTable::from_polars`]
+    /// directly - though the alignment copy will still occur per chunk
+    /// that isn't pre-aligned.
     ///
     /// Panics on FFI failure. For a fallible variant, see
     /// [`Table::try_from_polars`].
@@ -788,16 +821,8 @@ impl Table {
     /// Fallible variant of [`Table::from_polars`].
     #[cfg(feature = "cast_polars")]
     pub fn try_from_polars(df: &DataFrame) -> Result<Table, MinarrowError> {
-        let columns = df.columns();
-        let mut cols = Vec::with_capacity(columns.len());
-        for column in columns {
-            // Polars Column owns its data either as a Series or scalar; materialise
-            // into a single chunked Series so we can hit the polars_arrow FFI path.
-            let series = column.as_materialized_series();
-            let fa = FieldArray::try_from_polars(series)?;
-            cols.push(fa);
-        }
-        Ok(Table::new(String::new(), Some(cols)))
+        use crate::traits::consolidate::Consolidate;
+        Ok(SuperTable::try_from_polars(df)?.consolidate())
     }
 }
 

--- a/tests/polars.rs
+++ b/tests/polars.rs
@@ -628,6 +628,104 @@ fn rt_polars_empty_super_table() {
 
 // ----- Time32 / Time64 polars round-trip (real round-trip, not just export) -----
 
+// ----- Regression: multi-chunk Series must materialise fully -----
+//
+// Reported by kpiwonski: a 150-row iris CSV loaded via polars CsvReader
+// produced a multi-chunked Series. `FieldArray::from_polars` and
+// `Table::from_polars` previously read only chunk 0 (the first 2 rows)
+// because they called `s.to_arrow(0, ...)` once. The fix routes them
+// through `SuperArray::from_polars` / `SuperTable::from_polars` followed
+// by `consolidate`, so every chunk's data survives.
+
+#[test]
+fn rt_polars_field_array_from_multi_chunk_series() {
+    use minarrow::FieldArray;
+
+    // Build a Series with 3 explicit chunks of different sizes.
+    let mut s = Series::new("col".into(), &[1_i32, 2, 3]);
+    let s_b = Series::new("col".into(), &[4_i32, 5]);
+    let s_c = Series::new("col".into(), &[6_i32, 7, 8, 9, 10]);
+    s.append(&s_b).unwrap();
+    s.append(&s_c).unwrap();
+    assert!(s.n_chunks() > 1, "test precondition: multi-chunk Series");
+    assert_eq!(s.len(), 10);
+
+    let fa = FieldArray::from_polars(&s);
+    assert_eq!(fa.field.name, "col");
+    assert_eq!(fa.field.dtype, ArrowType::Int32);
+    assert_eq!(fa.len(), 10, "all chunks must survive the import");
+
+    // Verify the actual values
+    match &fa.array {
+        Array::NumericArray(NumericArray::Int32(arr)) => {
+            assert_eq!(&arr.data[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        }
+        other => panic!("expected Int32 array, got {:?}", other),
+    }
+}
+
+#[test]
+fn rt_polars_array_from_multi_chunk_series() {
+    // Same test for bare-Array path
+    let mut s = Series::new("x".into(), &[10_i64, 20]);
+    let s_b = Series::new("x".into(), &[30_i64, 40, 50]);
+    s.append(&s_b).unwrap();
+    assert!(s.n_chunks() > 1);
+    assert_eq!(s.len(), 5);
+
+    let a = Array::from_polars(&s);
+    assert_eq!(a.len(), 5);
+    match &a {
+        Array::NumericArray(NumericArray::Int64(arr)) => {
+            assert_eq!(&arr.data[..], &[10, 20, 30, 40, 50]);
+        }
+        other => panic!("expected Int64 array, got {:?}", other),
+    }
+}
+
+#[test]
+fn rt_polars_table_from_multi_chunk_dataframe() {
+    // Two columns, each with 2 chunks of different sizes, aligned to the
+    // same chunk boundaries (3+2 rows). DataFrame::from_polars should
+    // consolidate the columns to a single contiguous Table.
+    let mut a = Series::new("a".into(), &[1_i32, 2, 3]);
+    let a_b = Series::new("a".into(), &[4_i32, 5]);
+    a.append(&a_b).unwrap();
+    let mut b = Series::new("b".into(), &["x", "y", "z"]);
+    let b_b = Series::new("b".into(), &["w", "v"]);
+    b.append(&b_b).unwrap();
+    assert!(a.n_chunks() > 1);
+    assert!(b.n_chunks() > 1);
+
+    let df = DataFrame::new(5, vec![a.into_column(), b.into_column()]).unwrap();
+    assert_eq!(df.height(), 5);
+
+    let t = Table::from_polars(&df);
+    assert_eq!(t.n_rows(), 5, "all rows across chunks must survive");
+    assert_eq!(t.n_cols(), 2);
+    assert_eq!(t.col_names(), &["a", "b"]);
+
+    // Verify each column's values to ensure consolidation merged the
+    // chunks in order rather than dropping any.
+    match &t.cols[0].array {
+        Array::NumericArray(NumericArray::Int32(arr)) => {
+            assert_eq!(&arr.data[..], &[1, 2, 3, 4, 5]);
+        }
+        other => panic!("col 'a': expected Int32, got {:?}", other),
+    }
+    match &t.cols[1].array {
+        Array::TextArray(TextArray::String32(arr)) => {
+            let vals: Vec<&str> = (0..arr.len()).map(|i| arr.get_str(i).unwrap()).collect();
+            assert_eq!(vals, vec!["x", "y", "z", "w", "v"]);
+        }
+        Array::TextArray(TextArray::String64(arr)) => {
+            let vals: Vec<&str> = (0..arr.len()).map(|i| arr.get_str(i).unwrap()).collect();
+            assert_eq!(vals, vec!["x", "y", "z", "w", "v"]);
+        }
+        other => panic!("col 'b': expected String, got {:?}", other),
+    }
+}
+
 // ----- Time32 / Time64 polars round-trip -----
 //
 // Polars normalises ALL Time* logical types to `Time64(Nanoseconds)` internally


### PR DESCRIPTION
Array, FieldArray and Table from_polars now route through SuperArray::from_polars / SuperTable::from_polars.

Adds three regression tests covering FieldArray, Array and Table imports from multi-chunked Series and DataFrame inputs.

Improved polars docs.