### PR TITLE
views: 'non-window' fast path on all view->owned conversions

### DIFF
--- a/src/structs/buffer.rs
+++ b/src/structs/buffer.rs
@@ -230,7 +230,7 @@ impl<T> Buffer<T> {
     /// Construct a zero-copy buffer as a window into a SharedBuffer.
     ///
     /// The buffer views elements `[offset .. offset + len]` of type T within
-    /// the shared allocation. The SharedBuffer is cloned (via a refcount bump) 
+    /// the shared allocation. The SharedBuffer is cloned (via a refcount bump)
     /// so the underlying memory stays alive.
     ///
     /// This is used by Matrix::to_table to create per-column FloatArray

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -723,6 +723,17 @@ impl From<Array> for ArrayV {
     }
 }
 
+/// ArrayView -> Array
+///
+/// Delegates to `to_array`, which Arc-bumps the underlying allocation when the
+/// view spans its full backing array (offset = 0, len = array.len()) and only
+/// reallocates via `slice_clone` for genuinely windowed views.
+impl From<ArrayV> for Array {
+    fn from(view: ArrayV) -> Self {
+        view.to_array()
+    }
+}
+
 /// FieldArray -> ArrayView
 ///
 /// Takes self.array then offset 0, length self.len())

--- a/src/structs/views/bitmask_view.rs
+++ b/src/structs/views/bitmask_view.rs
@@ -142,9 +142,17 @@ impl BitmaskV {
         self.bitmask.slice(self.offset, self.len)
     }
 
-    /// Returns a Bitmask copy of the view.
+    /// Returns an owned `Bitmask` for the window.
+    ///
+    /// If the view covers the entire backing bitmask, returns a clone of the
+    /// underlying `Bitmask` (cheap for `Shared` storage; a byte memcpy for
+    /// `Owned` storage). Otherwise falls back to bit-by-bit `slice_clone`,
+    /// which has to honour bit alignment across the window boundary.
     #[inline]
     pub fn to_bitmask(&self) -> Bitmask {
+        if self.offset == 0 && self.len == self.bitmask.len() {
+            return (*self.bitmask).clone();
+        }
         self.bitmask.slice_clone(self.offset, self.len)
     }
 
@@ -476,5 +484,33 @@ mod tests {
         assert!(dbg.contains("BitmaskView"));
         assert!(dbg.contains("offset"));
         assert!(dbg.contains("set_count"));
+    }
+
+    #[test]
+    fn test_to_bitmask_full_coverage_matches_source() {
+        let bits = [true, false, true, false, true];
+        let mask = Bitmask::from_bools(&bits);
+        let view = BitmaskV::new(mask.clone(), 0, 5);
+        let out = view.to_bitmask();
+
+        assert_eq!(out.len(), 5);
+        for (i, expected) in bits.iter().enumerate() {
+            assert_eq!(out.get(i), *expected, "bit {} mismatched", i);
+        }
+        assert_eq!(out, mask, "full-coverage to_bitmask should equal the source bitmask");
+    }
+
+    #[test]
+    fn test_to_bitmask_windowed_matches_slice() {
+        let bits = [true, false, true, false, true, false];
+        let mask = Bitmask::from_bools(&bits);
+        let view = BitmaskV::new(mask, 2, 3);
+        let out = view.to_bitmask();
+
+        assert_eq!(out.len(), 3);
+        // Window is bits[2..5] = [true, false, true]
+        assert!(out.get(0));
+        assert!(!out.get(1));
+        assert!(out.get(2));
     }
 }

--- a/src/structs/views/collections/boolean_array_view.rs
+++ b/src/structs/views/collections/boolean_array_view.rs
@@ -166,8 +166,15 @@ impl BooleanArrayV {
         Array::BooleanArray(self.array.clone()) // Arc clone for data buffer
     }
 
-    /// Returns an owned `BooleanArray` clone of the window.
+    /// Returns an owned `BooleanArray` for the window.
+    ///
+    /// If the view covers the entire backing array, returns a cheap Arc clone
+    /// of the original allocation. Otherwise deep-copies the window via
+    /// `slice_clone` through `inner_array`.
     pub fn to_boolean_array(&self) -> Arc<BooleanArray<()>> {
+        if self.offset == 0 && self.len == self.array.len() {
+            return self.array.clone();
+        }
         self.inner_array().slice_clone(self.offset, self.len).bool()
     }
 
@@ -528,5 +535,39 @@ mod tests {
         assert_eq!(bool_view.offset, 1);
         assert_eq!(bool_view.get_bool(0), Some(false));
         assert_eq!(bool_view.get_bool(1), Some(true));
+    }
+
+    #[test]
+    fn test_to_boolean_array_full_coverage_shares_arc() {
+        let mut arr = BooleanArray::<()>::default();
+        arr.push(true);
+        arr.push(false);
+        arr.push(true);
+        let src = Arc::new(arr);
+
+        let view = BooleanArrayV::new(src.clone(), 0, 3);
+        let out = view.to_boolean_array();
+
+        assert!(
+            Arc::ptr_eq(&src, &out),
+            "full-coverage to_boolean_array should share the underlying Arc"
+        );
+    }
+
+    #[test]
+    fn test_to_boolean_array_windowed_copies() {
+        let mut arr = BooleanArray::<()>::default();
+        arr.push(true);
+        arr.push(false);
+        arr.push(true);
+        let src = Arc::new(arr);
+
+        let view = BooleanArrayV::new(src.clone(), 1, 2);
+        let out = view.to_boolean_array();
+
+        assert!(
+            !Arc::ptr_eq(&src, &out),
+            "windowed to_boolean_array must allocate a fresh buffer"
+        );
     }
 }

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -213,8 +213,15 @@ impl NumericArrayV {
         }
     }
 
-    /// Materialise a deep copy as an owned NumericArray for the window.
+    /// Materialise as an owned `NumericArray` for the window.
+    ///
+    /// If the view covers the entire backing array, returns a cheap Arc clone
+    /// of the original variant. Otherwise deep-copies the window via
+    /// `slice_clone` through `inner_array`.
     pub fn to_numeric_array(&self) -> NumericArray {
+        if self.offset == 0 && self.len == self.array.len() {
+            return self.array.clone();
+        }
         self.inner_array().slice_clone(self.offset, self.len).num()
     }
 
@@ -603,5 +610,47 @@ mod tests {
     fn test_numeric_array_view_from_array_panics_on_wrong_variant() {
         let array = Array::Null;
         let _view = NumericArrayV::from(array);
+    }
+
+    #[test]
+    fn test_to_numeric_array_full_coverage_shares_arc() {
+        let mut arr = IntegerArray::<i32>::default();
+        arr.push(1);
+        arr.push(2);
+        arr.push(3);
+        let src = Arc::new(arr);
+        let numeric = NumericArray::Int32(src.clone());
+
+        let view = NumericArrayV::new(numeric, 0, 3);
+        let out = view.to_numeric_array();
+
+        match out {
+            NumericArray::Int32(out_arc) => assert!(
+                Arc::ptr_eq(&src, &out_arc),
+                "full-coverage to_numeric_array should share the underlying Arc"
+            ),
+            _ => panic!("expected Int32 variant"),
+        }
+    }
+
+    #[test]
+    fn test_to_numeric_array_windowed_copies() {
+        let mut arr = IntegerArray::<i32>::default();
+        arr.push(1);
+        arr.push(2);
+        arr.push(3);
+        let src = Arc::new(arr);
+        let numeric = NumericArray::Int32(src.clone());
+
+        let view = NumericArrayV::new(numeric, 1, 2);
+        let out = view.to_numeric_array();
+
+        match out {
+            NumericArray::Int32(out_arc) => assert!(
+                !Arc::ptr_eq(&src, &out_arc),
+                "windowed to_numeric_array must allocate a fresh buffer"
+            ),
+            _ => panic!("expected Int32 variant"),
+        }
     }
 }

--- a/src/structs/views/collections/temporal_array_view.rs
+++ b/src/structs/views/collections/temporal_array_view.rs
@@ -196,8 +196,15 @@ impl TemporalArrayV {
         Array::TemporalArray(self.array.clone()) // Arc clone for data buffer
     }
 
-    /// Converts the view into a sliced `TemporalArray`.
+    /// Converts the view into an owned `TemporalArray` for the window.
+    ///
+    /// If the view covers the entire backing array, returns a cheap Arc clone
+    /// of the original variant. Otherwise deep-copies the window via
+    /// `slice_clone` through `inner_array`.
     pub fn to_temporal_array(&self) -> TemporalArray {
+        if self.offset == 0 && self.len == self.array.len() {
+            return self.array.clone();
+        }
         self.inner_array().slice_clone(self.offset, self.len).dt()
     }
 
@@ -832,5 +839,41 @@ mod tests {
     fn test_temporal_array_view_from_array_panics_on_wrong_variant() {
         let array = Array::Null;
         let _view = TemporalArrayV::from(array);
+    }
+
+    #[test]
+    fn test_to_temporal_array_full_coverage_shares_arc() {
+        let arr = DatetimeArray::<i64>::from_slice(&[10, 20, 30], None);
+        let src = Arc::new(arr);
+        let temporal = TemporalArray::Datetime64(src.clone());
+
+        let view = TemporalArrayV::new(temporal, 0, 3);
+        let out = view.to_temporal_array();
+
+        match out {
+            TemporalArray::Datetime64(out_arc) => assert!(
+                Arc::ptr_eq(&src, &out_arc),
+                "full-coverage to_temporal_array should share the underlying Arc"
+            ),
+            _ => panic!("expected Datetime64 variant"),
+        }
+    }
+
+    #[test]
+    fn test_to_temporal_array_windowed_copies() {
+        let arr = DatetimeArray::<i64>::from_slice(&[10, 20, 30], None);
+        let src = Arc::new(arr);
+        let temporal = TemporalArray::Datetime64(src.clone());
+
+        let view = TemporalArrayV::new(temporal, 1, 2);
+        let out = view.to_temporal_array();
+
+        match out {
+            TemporalArray::Datetime64(out_arc) => assert!(
+                !Arc::ptr_eq(&src, &out_arc),
+                "windowed to_temporal_array must allocate a fresh buffer"
+            ),
+            _ => panic!("expected Datetime64 variant"),
+        }
     }
 }

--- a/src/structs/views/collections/text_array_view.rs
+++ b/src/structs/views/collections/text_array_view.rs
@@ -181,8 +181,15 @@ impl TextArrayV {
         Array::TextArray(self.array.clone()) // Arc clone for data buffer
     }
 
-    /// Returns an owned `TextArray` clone of the window.
+    /// Returns an owned `TextArray` for the window.
+    ///
+    /// If the view covers the entire backing array, returns a cheap Arc clone
+    /// of the original variant. Otherwise deep-copies the window via
+    /// `slice_clone` through `inner_array`.
     pub fn to_text_array(&self) -> TextArray {
+        if self.offset == 0 && self.len == self.array.len() {
+            return self.array.clone();
+        }
         self.inner_array().slice_clone(self.offset, self.len).str()
     }
 
@@ -491,5 +498,41 @@ mod tests {
     fn test_text_array_view_from_array_panics_on_wrong_variant() {
         let array = Array::Null;
         let _view = TextArrayV::from(array);
+    }
+
+    #[test]
+    fn test_to_text_array_full_coverage_shares_arc() {
+        let arr = StringArray::<u32>::from_slice(&["a", "b", "c"]);
+        let src = Arc::new(arr);
+        let text = TextArray::String32(src.clone());
+
+        let view = TextArrayV::new(text, 0, 3);
+        let out = view.to_text_array();
+
+        match out {
+            TextArray::String32(out_arc) => assert!(
+                Arc::ptr_eq(&src, &out_arc),
+                "full-coverage to_text_array should share the underlying Arc"
+            ),
+            _ => panic!("expected String32 variant"),
+        }
+    }
+
+    #[test]
+    fn test_to_text_array_windowed_copies() {
+        let arr = StringArray::<u32>::from_slice(&["a", "b", "c"]);
+        let src = Arc::new(arr);
+        let text = TextArray::String32(src.clone());
+
+        let view = TextArrayV::new(text, 1, 2);
+        let out = view.to_text_array();
+
+        match out {
+            TextArray::String32(out_arc) => assert!(
+                !Arc::ptr_eq(&src, &out_arc),
+                "windowed to_text_array must allocate a fresh buffer"
+            ),
+            _ => panic!("expected String32 variant"),
+        }
     }
 }

--- a/src/structs/views/table_view.rs
+++ b/src/structs/views/table_view.rs
@@ -373,6 +373,10 @@ impl TableV {
     }
 
     /// Materialise the view into an owned Table. Respects active column selection.
+    ///
+    /// Each column delegates to `ArrayV::to_array()`, which avoids a buffer copy
+    /// when the column window already spans its full backing array. Genuinely
+    /// row-windowed columns fall through to `slice_clone` inside `to_array`.
     pub fn to_table(&self) -> Table {
         let col_indices = self.active_col_indices();
         let cols: Vec<_> = col_indices
@@ -380,14 +384,13 @@ impl TableV {
             .filter_map(|&col_idx| {
                 let field = self.fields.get(col_idx)?;
                 let window = self.cols.get(col_idx)?;
-                let w = window.as_tuple();
 
-                let sliced = w.0.slice_clone(w.1, w.2);
-                let null_count = sliced.null_count();
+                let array = window.to_array();
+                let null_count = array.null_count();
 
                 Some(FieldArray {
                     field: field.clone(),
-                    array: sliced,
+                    array,
                     null_count,
                 })
             })
@@ -1189,5 +1192,86 @@ mod tests {
         let empty = full_view.r(0..0);
         assert_eq!(empty.len(), 0);
         assert_eq!(empty.to_table().n_rows(), 0);
+    }
+
+    /// Pull out the inner `Arc<IntegerArray<i32>>` from a column for pointer-identity
+    /// checks. Asserts the column is the expected variant.
+    #[cfg(test)]
+    fn i32_arc(table: &Table, col_idx: usize) -> Arc<crate::IntegerArray<i32>> {
+        use crate::NumericArray;
+        match &table.cols[col_idx].array {
+            Array::NumericArray(NumericArray::Int32(arc)) => arc.clone(),
+            other => panic!("expected Int32 column, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_to_table_full_coverage_shares_arc() {
+        let fa_a = fa_i32!("a", 1, 2, 3, 4, 5);
+        let fa_b = fa_i32!("b", 10, 20, 30, 40, 50);
+
+        let mut tbl = Table::new_empty();
+        tbl.add_col(fa_a);
+        tbl.add_col(fa_b);
+
+        let src_a = i32_arc(&tbl, 0);
+        let src_b = i32_arc(&tbl, 1);
+
+        // Full-coverage view: offset=0, len matches each column's full length.
+        let view = TableV::from_table(tbl, 0, 5);
+        let materialised = view.to_table();
+
+        let out_a = i32_arc(&materialised, 0);
+        let out_b = i32_arc(&materialised, 1);
+
+        // Same allocation reused, not a fresh buffer copy.
+        assert!(Arc::ptr_eq(&src_a, &out_a), "column a should share the underlying Arc on full-coverage to_table");
+        assert!(Arc::ptr_eq(&src_b, &out_b), "column b should share the underlying Arc on full-coverage to_table");
+    }
+
+    #[test]
+    fn test_to_table_row_windowed_copies() {
+        let fa_a = fa_i32!("a", 1, 2, 3, 4, 5);
+
+        let mut tbl = Table::new_empty();
+        tbl.add_col(fa_a);
+
+        let src_a = i32_arc(&tbl, 0);
+
+        // Genuine row window forces per-column slice_clone (no fast path).
+        let view = TableV::from_table(tbl, 1, 3);
+        let materialised = view.to_table();
+        let out_a = i32_arc(&materialised, 0);
+
+        assert!(!Arc::ptr_eq(&src_a, &out_a), "row-windowed to_table must not alias the source buffer");
+        assert_eq!(materialised.n_rows(), 3);
+    }
+
+    #[cfg(feature = "select")]
+    #[test]
+    fn test_to_table_column_projection_kept_columns_share_arc() {
+        let fa_a = fa_i32!("a", 1, 2, 3, 4, 5);
+        let fa_b = fa_i32!("b", 10, 20, 30, 40, 50);
+        let fa_c = fa_i32!("c", 100, 200, 300, 400, 500);
+
+        let mut tbl = Table::new_empty();
+        tbl.add_col(fa_a);
+        tbl.add_col(fa_b);
+        tbl.add_col(fa_c);
+
+        let src_a = i32_arc(&tbl, 0);
+        let src_c = i32_arc(&tbl, 2);
+
+        // Drop column "b" via projection. Rows are still full coverage on the kept
+        // columns, so a and c should both bypass the buffer copy.
+        let view = TableV::from_table(tbl, 0, 5).c(vec!["a", "c"]);
+        let materialised = view.to_table();
+
+        assert_eq!(materialised.n_cols(), 2);
+        let out_a = i32_arc(&materialised, 0);
+        let out_c = i32_arc(&materialised, 1);
+
+        assert!(Arc::ptr_eq(&src_a, &out_a), "kept column a should share Arc under projection");
+        assert!(Arc::ptr_eq(&src_c, &out_c), "kept column c should share Arc under projection");
     }
 }


### PR DESCRIPTION
When a view spans its full backing storage (offset = 0 and len matches the backing array's length), skip slice_clone and return a cheap Arc clone of the underlying allocation instead.

Add zero-sized buffer checks