### PR TITLE
Add arr_dt32! and arr_dt64! macros for datetime array construction

### DIFF
--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -3364,6 +3364,74 @@ macro_rules! arr_i64 {
     };
 }
 
+// ======== Datetime (i32) ========
+
+/// Build an `Array` of i32-backed datetimes. The time unit is
+/// required and precedes the values, separated by `;`.
+///
+/// ```ignore
+/// use minarrow::ffi::arrow_dtype::TimeUnit;
+/// let a = arr_dt32![TimeUnit::Seconds; 1_768_521_600, 1_775_865_600];
+/// let b = arr_dt32![TimeUnit::Milliseconds; vec64![1, 2, 3]];
+/// ```
+#[cfg(feature = "datetime")]
+#[macro_export]
+macro_rules! arr_dt32 {
+    ($unit:expr; $v:expr) => {
+        $crate::Array::from_datetime_i32($crate::DatetimeArray::<i32>::from_vec64(
+            $v, None, Some($unit),
+        ))
+    };
+    ($unit:expr; $($x:expr),+ $(,)?) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_datetime_i32($crate::DatetimeArray::<i32>::from_vec64(
+            temp_vec, None, Some($unit),
+        ))
+    }};
+    ($unit:expr;) => {
+        $crate::Array::from_datetime_i32($crate::DatetimeArray::<i32>::from_vec64(
+            $crate::Vec64::new(),
+            None,
+            Some($unit),
+        ))
+    };
+}
+
+// ======== Datetime (i64) ========
+
+/// Build an `Array` of i64-backed datetimes. The time unit is
+/// required and precedes the values, separated by `;`.
+///
+/// ```ignore
+/// use minarrow::ffi::arrow_dtype::TimeUnit;
+/// let a = arr_dt64![TimeUnit::Seconds; 1_768_521_600, 1_775_865_600];
+/// let b = arr_dt64![TimeUnit::Milliseconds; vec64![1, 2, 3]];
+/// ```
+#[cfg(feature = "datetime")]
+#[macro_export]
+macro_rules! arr_dt64 {
+    ($unit:expr; $v:expr) => {
+        $crate::Array::from_datetime_i64($crate::DatetimeArray::<i64>::from_vec64(
+            $v, None, Some($unit),
+        ))
+    };
+    ($unit:expr; $($x:expr),+ $(,)?) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_datetime_i64($crate::DatetimeArray::<i64>::from_vec64(
+            temp_vec, None, Some($unit),
+        ))
+    }};
+    ($unit:expr;) => {
+        $crate::Array::from_datetime_i64($crate::DatetimeArray::<i64>::from_vec64(
+            $crate::Vec64::new(),
+            None,
+            Some($unit),
+        ))
+    };
+}
+
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! arr_u8 {


### PR DESCRIPTION
Mirrors arr_i32! / arr_i64! but wraps the values in a DatetimeArray and requires the caller to supply the time unit. 

    arr_dt64![TimeUnit::Seconds; 1_767_225_600, 1_769_904_000]
    arr_dt64![TimeUnit::Milliseconds; vec64![1, 2, 3]]

Closes a gap in the macro family - previously datetime construction required spelling out Array::from_datetime_i64(DatetimeArray::<i64> ::from_slice(.., Some(TimeUnit::Seconds))) at every callsite.