### PR TITLE
Repo audit

### DIFF
--- a/src/enums/collections/numeric_array.rs
+++ b/src/enums/collections/numeric_array.rs
@@ -745,10 +745,10 @@ impl Display for NumericArray {
 }
 
 /// Writes the standard header, then delegates to the contained array's Display.
-fn write_numeric_array_with_header<T>(
+fn write_numeric_array_with_header(
     f: &mut Formatter<'_>,
     dtype_name: &str,
-    arr: &(impl MaskedArray<CopyType = T> + Display + ?Sized),
+    arr: &(impl MaskedArray + Display + ?Sized),
 ) -> std::fmt::Result {
     writeln!(
         f,

--- a/src/enums/collections/temporal_array.rs
+++ b/src/enums/collections/temporal_array.rs
@@ -666,10 +666,10 @@ impl Display for TemporalArray {
 }
 
 /// Writes the standard header, then delegates to the contained array's Display.
-fn write_temporal_array_with_header<T>(
+fn write_temporal_array_with_header(
     f: &mut Formatter<'_>,
     dtype: &str,
-    arr: &(impl MaskedArray<CopyType = T> + Display + ?Sized),
+    arr: &(impl MaskedArray + Display + ?Sized),
 ) -> std::fmt::Result {
     writeln!(
         f,

--- a/src/enums/collections/text_array.rs
+++ b/src/enums/collections/text_array.rs
@@ -585,10 +585,10 @@ impl Display for TextArray {
 }
 
 /// Writes the header, then delegates row printing to the array's Display.
-fn write_text_array_with_header<T>(
+fn write_text_array_with_header(
     f: &mut Formatter<'_>,
     dtype: &str,
-    arr: &(impl MaskedArray<CopyType = T> + Display + ?Sized),
+    arr: &(impl MaskedArray + Display + ?Sized),
 ) -> std::fmt::Result {
     writeln!(
         f,

--- a/src/enums/value/conversions.rs
+++ b/src/enums/value/conversions.rs
@@ -24,6 +24,7 @@ use crate::Cube;
 use crate::Matrix;
 #[cfg(feature = "scalar_type")]
 use crate::Scalar;
+use crate::traits::masked_array::MaskedArray;
 use crate::{Array, FieldArray, Table, enums::error::MinarrowError};
 use std::convert::TryFrom;
 use std::sync::Arc;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -111,7 +111,7 @@ macro_rules! impl_masked_array {
             type T = T;
             type Container = $container;
             type LogicalType = $logicaltype;
-            type CopyType = $logicaltype; // (currently the) same for all macro-implemented types
+            type CopyType<'a> = $logicaltype where Self: 'a;
 
             /// Returns a reference to the underlying data vector.
             fn data(&self) -> &Buffer<T> {
@@ -906,7 +906,7 @@ macro_rules! impl_arc_masked_array {
             type T = $T;
             type Container = $Container;
             type LogicalType = $LogicalType;
-            type CopyType = $CopyType;
+            type CopyType<'a> = $CopyType where Self: 'a;
 
             fn len(&self) -> usize {
                 (**self).len()
@@ -920,36 +920,36 @@ macro_rules! impl_arc_masked_array {
             fn data_mut(&mut self) -> &mut Self::Container {
                 ::std::sync::Arc::make_mut(self).data_mut()
             }
-            fn get(&self, idx: usize) -> Option<Self::CopyType> {
+            fn get(&self, idx: usize) -> Option<Self::CopyType<'_>> {
                 (**self).get(idx)
             }
             fn set(&mut self, idx: usize, value: Self::LogicalType) {
                 ::std::sync::Arc::make_mut(self).set(idx, value)
             }
-            unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType> {
+            unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType<'_>> {
                 unsafe { (**self).get_unchecked(idx) }
             }
             unsafe fn set_unchecked(&mut self, idx: usize, value: Self::LogicalType) {
                 unsafe { ::std::sync::Arc::make_mut(self).set_unchecked(idx, value) }
             }
-            fn iter(&self) -> impl Iterator<Item = Self::CopyType> + '_ {
+            fn iter(&self) -> impl Iterator<Item = Self::CopyType<'_>> + '_ {
                 (**self).iter()
             }
-            fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType>> + '_ {
+            fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_ {
                 (**self).iter_opt()
             }
             fn iter_range(
                 &self,
                 offset: usize,
                 len: usize,
-            ) -> impl Iterator<Item = Self::CopyType> + '_ {
+            ) -> impl Iterator<Item = Self::CopyType<'_>> + '_ {
                 (**self).iter_range(offset, len)
             }
             fn iter_opt_range(
                 &self,
                 offset: usize,
                 len: usize,
-            ) -> impl Iterator<Item = Option<Self::CopyType>> + '_ {
+            ) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_ {
                 (**self).iter_opt_range(offset, len)
             }
             fn push(&mut self, value: Self::LogicalType) {
@@ -1030,7 +1030,7 @@ macro_rules! impl_arc_masked_array {
             type T = $T;
             type Container = $Container;
             type LogicalType = $LogicalType;
-            type CopyType = $CopyType;
+            type CopyType<'a> = $CopyType where Self: 'a;
 
             fn len(&self) -> usize {
                 (**self).len()
@@ -1044,36 +1044,36 @@ macro_rules! impl_arc_masked_array {
             fn data_mut(&mut self) -> &mut Self::Container {
                 ::std::sync::Arc::make_mut(self).data_mut()
             }
-            fn get(&self, idx: usize) -> Option<Self::CopyType> {
+            fn get(&self, idx: usize) -> Option<Self::CopyType<'_>> {
                 (**self).get(idx)
             }
             fn set(&mut self, idx: usize, value: Self::LogicalType) {
                 ::std::sync::Arc::make_mut(self).set(idx, value)
             }
-            unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType> {
+            unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType<'_>> {
                 unsafe { (**self).get_unchecked(idx) }
             }
             unsafe fn set_unchecked(&mut self, idx: usize, value: Self::LogicalType) {
                 unsafe { ::std::sync::Arc::make_mut(self).set_unchecked(idx, value) }
             }
-            fn iter(&self) -> impl Iterator<Item = Self::CopyType> + '_ {
+            fn iter(&self) -> impl Iterator<Item = Self::CopyType<'_>> + '_ {
                 (**self).iter()
             }
-            fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType>> + '_ {
+            fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_ {
                 (**self).iter_opt()
             }
             fn iter_range(
                 &self,
                 offset: usize,
                 len: usize,
-            ) -> impl Iterator<Item = Self::CopyType> + '_ {
+            ) -> impl Iterator<Item = Self::CopyType<'_>> + '_ {
                 (**self).iter_range(offset, len)
             }
             fn iter_opt_range(
                 &self,
                 offset: usize,
                 len: usize,
-            ) -> impl Iterator<Item = Option<Self::CopyType>> + '_ {
+            ) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_ {
                 (**self).iter_opt_range(offset, len)
             }
             fn push(&mut self, value: Self::LogicalType) {

--- a/src/structs/variants/boolean.rs
+++ b/src/structs/variants/boolean.rs
@@ -354,7 +354,7 @@ impl MaskedArray for BooleanArray<()> {
     type T = bool;
     type Container = Bitmask;
     type LogicalType = bool;
-    type CopyType = bool;
+    type CopyType<'a> = bool where Self: 'a;
 
     fn data(&self) -> &Bitmask {
         &self.data

--- a/src/structs/variants/categorical.rs
+++ b/src/structs/variants/categorical.rs
@@ -410,11 +410,7 @@ impl<T: Integer> CategoricalArray<T> {
             if self.is_null(idx) {
                 None
             } else {
-                Some(unsafe {
-                    std::mem::transmute::<&str, &'static str>(
-                        &self.unique_values[dict_idx.to_usize()],
-                    )
-                })
+                Some(self.unique_values[dict_idx.to_usize()].as_str())
             }
         })
     }
@@ -450,11 +446,7 @@ impl<T: Integer> CategoricalArray<T> {
                 if self.is_null(idx) {
                     None
                 } else {
-                    Some(unsafe {
-                        std::mem::transmute::<&str, &'static str>(
-                            &self.unique_values[dict_idx.to_usize()],
-                        )
-                    })
+                    Some(self.unique_values[dict_idx.to_usize()].as_str())
                 }
             })
     }
@@ -530,7 +522,7 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
 
     type LogicalType = String;
 
-    type CopyType = &'static str;
+    type CopyType<'a> = &'a str where Self: 'a;
 
     #[inline]
     fn len(&self) -> usize {
@@ -547,31 +539,24 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
 
     /// Retrieves the value at the given index, or `None` if null.
     ///
-    /// # ⚠️ WARNING - prefer `get_str`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `get_str` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
+    /// The returned `&str` borrows from `self`, tied to the lifetime of `&self`
+    /// via the trait's GAT `CopyType<'a>`.
     ///
     /// # Panics
     /// Panics if `idx >= self.len()` or if `data[idx]` is an invalid index into `unique_values`.
     #[inline]
-    fn get(&self, idx: usize) -> Option<Self::CopyType> {
+    fn get(&self, idx: usize) -> Option<&str> {
         if self.is_null(idx) {
             return None;
         }
 
         let dict_idx = self.data[idx].to_usize();
-
-        // SAFETY: Must not escape beyond the borrow lifetime of self.
-        Some(unsafe { std::mem::transmute::<&str, &'static str>(&self.unique_values[dict_idx]) })
+        Some(&self.unique_values[dict_idx])
     }
 
     /// Sets the value at `idx`. Marks as valid.
     ///
-    /// # ⚠️ Prefer `set_str`, which avoids a reallocation.
+    /// Prefer `set_str` when you have a `&str` to avoid the `String` allocation.
     #[inline]
     fn set(&mut self, idx: usize, value: Self::LogicalType) {
         self.set_str(idx, &value)
@@ -579,24 +564,12 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
 
     /// Like `get`, but skips bounds checks on both the data and dictionary index.
     ///
-    /// # ⚠️ WARNING - prefer `get_str_unchecked`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `get_str_unchecked` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
-    ///
     /// # Safety
     /// Caller must ensure:
     /// - `idx` is within bounds of `self.data`
     /// - `self.data[idx]` yields a valid index into `self.unique_values`
-    /// - The result is not held beyond the lifetime of `self`
-    ///
-    /// The transmute casts the internal `&str` to `'static`, but this is only valid
-    /// as long as `self` is alive. Do **not** persist the reference.
     #[inline]
-    unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType> {
+    unsafe fn get_unchecked(&self, idx: usize) -> Option<&str> {
         if let Some(mask) = &self.null_mask {
             if !mask.get(idx) {
                 return None;
@@ -604,14 +577,12 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
         }
 
         let dict_idx = unsafe { self.data.get_unchecked(idx).to_usize().unwrap() };
-        Some(unsafe {
-            std::mem::transmute::<&str, &'static str>(self.unique_values.get_unchecked(dict_idx))
-        })
+        Some(unsafe { self.unique_values.get_unchecked(dict_idx).as_str() })
     }
 
     /// Like `set`, but skips all bounds checks.
     ///
-    /// ⚠️ Prefer `set_str_unchecked` as it avoids a reallocation.
+    /// Prefer `set_str_unchecked` when you have a `&str` to avoid the `String` allocation.
     #[inline]
     unsafe fn set_unchecked(&mut self, idx: usize, value: Self::LogicalType) {
         // find or insert
@@ -635,62 +606,38 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
         }
     }
 
-    /// Returns an iterator of `&'static str` values.
-    ///
-    /// # ⚠️ WARNING - prefer `iter_str`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `iter_str` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
+    /// Returns an iterator of `&str` values borrowed from `self`.
     ///
     /// Nulls are represented as an empty string `""`.
     #[inline]
-    fn iter(&self) -> impl Iterator<Item = Self::CopyType> + '_ {
+    fn iter(&self) -> impl Iterator<Item = &str> + '_ {
         self.data.iter().enumerate().map(move |(idx, &dict_idx)| {
             if self.is_null(idx) {
                 ""
             } else {
-                unsafe {
-                    std::mem::transmute::<&str, &'static str>(
-                        &self.unique_values[dict_idx.to_usize()],
-                    )
-                }
+                self.unique_values[dict_idx.to_usize()].as_str()
             }
         })
     }
 
-    /// Returns an iterator over `Option<&'static str>`, yielding `None` for nulls.
+    /// Returns an iterator over `Option<&str>`, yielding `None` for nulls.
     ///
-    /// # ⚠️ WARNING - prefer `iter_str_opt`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `iter_str_opt` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
+    /// The returned references borrow from `self`.
     #[inline]
-    fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType>> + '_ {
+    fn iter_opt(&self) -> impl Iterator<Item = Option<&str>> + '_ {
         self.data.iter().enumerate().map(move |(idx, &dict_idx)| {
             if self.is_null(idx) {
                 None
             } else {
-                Some(unsafe {
-                    std::mem::transmute::<&str, &'static str>(
-                        &self.unique_values[dict_idx.to_usize()],
-                    )
-                })
+                Some(self.unique_values[dict_idx.to_usize()].as_str())
             }
         })
     }
 
-    /// Returns an iterator of `&'static str` values for a specified range.
-    ///
-    /// ⚠️ WARNING - prefer `iter_str_range`
-    /// The returned references borrow from the backing buffer and are not truly static.
+    /// Returns an iterator of `&str` values for a specified range.
+    /// Nulls yield `""`.
     #[inline]
-    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = &'static str> + '_ {
+    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = &str> + '_ {
         self.data[offset..offset + len]
             .iter()
             .enumerate()
@@ -699,25 +646,18 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
                 if self.is_null(idx) {
                     ""
                 } else {
-                    unsafe {
-                        std::mem::transmute::<&str, &'static str>(
-                            &self.unique_values[dict_idx.to_usize()],
-                        )
-                    }
+                    self.unique_values[dict_idx.to_usize()].as_str()
                 }
             })
     }
 
-    /// Returns an iterator over `Option<&'static str>` values for a specified range.
-    ///
-    /// ⚠️ WARNING - prefer `iter_str_opt_range`
-    /// The returned references borrow from the backing buffer and are not truly static.
+    /// Returns an iterator over `Option<&str>` values for a specified range.
     #[inline]
     fn iter_opt_range(
         &self,
         offset: usize,
         len: usize,
-    ) -> impl Iterator<Item = Option<&'static str>> + '_ {
+    ) -> impl Iterator<Item = Option<&str>> + '_ {
         self.data[offset..offset + len]
             .iter()
             .enumerate()
@@ -726,26 +666,23 @@ impl<T: Integer> MaskedArray for CategoricalArray<T> {
                 if self.is_null(idx) {
                     None
                 } else {
-                    Some(unsafe {
-                        std::mem::transmute::<&str, &'static str>(
-                            &self.unique_values[dict_idx.to_usize()],
-                        )
-                    })
+                    Some(self.unique_values[dict_idx.to_usize()].as_str())
                 }
             })
     }
 
     /// Append string, adding to dictionary if new.
     ///
-    /// ⚠️ Prefer `push_str` as it avoids a reallocation.
+    /// Prefer `push_str` when you have a `&str` to avoid the `String` allocation;
+    /// it also returns the assigned dictionary code.
     #[inline]
     fn push(&mut self, value: Self::LogicalType) {
         self.push_str(&value);
     }
 
-    /// Append string, adding to dictionary if new, without bounds checking
+    /// Append string, adding to dictionary if new, without bounds checking.
     ///
-    /// ⚠️ Prefer `push_str_unchecked` as it avoids a reallocation.
+    /// Prefer `push_str_unchecked` when you have a `&str` to avoid the `String` allocation.
     ///
     /// # Safety
     /// - The caller must ensure `self.data` has sufficient capacity (i.e., already resized).
@@ -1307,7 +1244,7 @@ impl_arc_masked_array!(
     T = T,
     Container = Buffer<T>,
     LogicalType = String,
-    CopyType = &'static str,
+    CopyType = &'a str,
     BufferT = T,
     Variant = TextArray,
     Bound = Integer,

--- a/src/structs/variants/string.rs
+++ b/src/structs/variants/string.rs
@@ -37,13 +37,13 @@
 //! Use for variable-length UTF-8 text with Arrow interop, compact memory layout,
 //! and high-throughput append/scan workloads.
 //!
-//! ## Safety note
-//! Trait methods from `MaskedArray` that return `&'static str` are for trait
-//! compatibility only-the data actually borrows from `self`. Prefer the `*_str`
-//! methods in this module for correct lifetime management.
+//! ## Note on string borrows
+//! `MaskedArray::get` / `iter` return `&str` borrowed from `self` (via the
+//! trait's GAT `CopyType<'a>`), so the borrow checker prevents the returned
+//! references from outliving the array. The inherent `*_str` methods on this
+//! type are equivalent and exist for backwards-compatibility.
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
-use std::mem::transmute;
 use std::ops::{Deref, DerefMut, Index, Range};
 
 use num_traits::{NumCast, Zero};
@@ -410,7 +410,7 @@ impl<T: Integer> StringArray<T> {
         })
     }
 
-    /// Pushes a string onto the array
+    /// Pushes a string onto the array.
     #[inline]
     pub fn push_str(&mut self, value: &str) {
         let len_before = <T as NumCast>::from(self.data.len()).unwrap();
@@ -507,7 +507,7 @@ impl<T: Integer> MaskedArray for StringArray<T> {
 
     type LogicalType = String;
 
-    type CopyType = &'static str;
+    type CopyType<'a> = &'a str where Self: 'a;
 
     fn data(&self) -> &Self::Container {
         &self.data
@@ -519,62 +519,25 @@ impl<T: Integer> MaskedArray for StringArray<T> {
 
     /// Returns the string value at the given index, or `None` if the value is null.
     ///
-    /// # ⚠️ WARNING - prefer `get_str`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `get_str` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
-    ///
-    /// This is an intentional (but unfortunate) design trade-off to maintain a uniform trait
-    /// interface across array types without introducing lifetime parameters everywhere.
-    /// For example, numeric types do not require lifetimes, and the alternatives would either be:
-    /// 1)  Forcing all non-string types to use `<'a>` across these main trait methods
-    /// 2)  Returning owned string copies rather than borrows.
-    ///  
-    /// Hence, prefer `get_str` when you have the option, and use this within its actual lifetime
-    /// context when you don't have a choice (i.e., when building off the trait contract).
-    ///
-    /// ## ⚠️ Incorrect Usage (do **not** do this):
-    ///
-    /// ```no_run
-    /// use minarrow::{MaskedArray, StringArray};
-    /// let s: &str;
-    /// {
-    ///     let arr = StringArray::<u32>::from_slice(&["a", "b"]);
-    ///     s = unsafe { arr.get(0).unwrap() }; // Not truly static
-    /// }
-    /// // ⚠️ Use-after-free - Undefined Behaviour
-    /// println!("{}", s);
-    /// ```
-    ///
-    /// # Safety
-    ///
-    /// - Caller must ensure `idx` is within bounds.
-    /// - The backing array must not be mutated or dropped for the duration of the borrow.
-    /// - The offsets and data must be valid.
+    /// The returned `&str` borrows from `self` via the trait's `CopyType<'a>`,
+    /// so the borrow checker will prevent it from outliving the array.
     ///
     /// # Panics
     /// Panics if offset values are inconsistent or indexing violates memory bounds.
     #[inline]
-    fn get(&self, idx: usize) -> Option<&'static str> {
+    fn get(&self, idx: usize) -> Option<&str> {
         if self.is_null(idx) {
             return None;
         }
         let start = self.offsets[idx].to_usize();
         let end = self.offsets[idx + 1].to_usize();
 
-        Some(unsafe {
-            std::mem::transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                &self.data[start..end],
-            ))
-        })
+        Some(unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) })
     }
 
     /// Sets the string at the given index, updating offsets, data buffer, and null mask.
     ///
-    /// # ⚠️ Prefer `set_str` as it avoids a reallocation.
+    /// Prefer `set_str` when you have a `&str` to avoid the `String` allocation.
     ///
     /// Panics if `idx >= self.len()`.
     #[inline]
@@ -582,49 +545,14 @@ impl<T: Integer> MaskedArray for StringArray<T> {
         self.set_str(idx, &value)
     }
 
-    /// Returns the string value at the given index, or `None` if the value is null,
-    /// without bounds checking. Prefer "unchecked" for performance critical code.
-    ///
-    /// # ⚠️ WARNING - prefer `get_str_unchecked`
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `get_str` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
-    ///
-    /// This is an intentional (but unfortunate) design trade-off to maintain a uniform trait
-    /// interface across array types without introducing lifetime parameters everywhere.
-    /// For example, numeric types do not require lifetimes, and the alternatives would either be:
-    /// 1)  Forcing all non-string types to use `<'a>` across these main trait methods
-    /// 2)  Returning owned string copies rather than borrows.
-    ///  
-    /// Hence, prefer `get_str` when you have the option, and use this within its actual lifetime
-    /// context when you don't have a choice (i.e., when building off the trait contract).
-    ///
-    /// ## ⚠️ Incorrect Usage (do **not** do this):
-    ///
-    /// ```no_run
-    /// use minarrow::{MaskedArray, StringArray};
-    /// let s: &str;
-    /// {
-    ///     let arr = StringArray::<u32>::from_slice(&["a", "b"]);
-    ///     s = unsafe { arr.get_unchecked(0).unwrap() }; // Not truly static
-    /// }
-    /// // ⚠️ Use-after-free - Undefined Behaviour
-    /// println!("{}", s);
-    /// ```
+    /// Returns the string value at the given index, or `None` if null,
+    /// without bounds checking.
     ///
     /// # Safety
-    ///
-    /// - Caller must ensure `idx` is within bounds.
-    /// - The backing array must not be mutated or dropped for the duration of the borrow.
-    /// - The offsets and data must be valid.
-    ///
-    /// # Panics
-    /// Panics if offset values are inconsistent or indexing violates memory bounds.
+    /// - Caller must ensure `idx` is within bounds of `self.offsets`.
+    /// - The offsets and data must be valid (monotonic, in-range).
     #[inline]
-    unsafe fn get_unchecked(&self, idx: usize) -> Option<&'static str> {
+    unsafe fn get_unchecked(&self, idx: usize) -> Option<&str> {
         // null‐check
         if let Some(mask) = &self.null_mask {
             if !mask.get(idx) {
@@ -634,133 +562,76 @@ impl<T: Integer> MaskedArray for StringArray<T> {
         // slice out the bytes without checking offsets bounds
         let start = unsafe { self.offsets.get_unchecked(idx).to_usize().unwrap() };
         let end = unsafe { self.offsets.get_unchecked(idx + 1).to_usize().unwrap() };
-        Some(unsafe {
-            std::mem::transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                &self.data[start..end],
-            ))
-        })
+        Some(unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) })
     }
 
     /// Like `set`, but skips bounds checks on `idx`.
     ///
-    /// # ⚠️ Prefer `set_str_unchecked` as it avoids a reallocation.
-    /// ```
+    /// Prefer `set_str_unchecked` when you have a `&str` to avoid the `String` allocation.
     #[inline]
     unsafe fn set_unchecked(&mut self, idx: usize, value: String) {
         unsafe { self.set_str_unchecked(idx, &value) };
     }
 
-    /// Returns an iterator over all values in the array, skipping null checks.
+    /// Returns an iterator over all values in the array.
     ///
-    /// # Safety Note
-    ///
-    /// # ⚠️ WARNING
-    /// This method returns a `&static str` for trait compatibility. However, the returned
-    /// reference **borrows from the backing buffer of the array** and must not outlive
-    /// the lifetime of `self`. It is **not truly static**.
-    ///
-    /// *Instead, prefer `iter_str` for practical use*, or, if you
-    /// are using this to build on top of the trait, ensure that you *do not store* the values.
-    ///
-    /// This is an intentional (but unfortunate) design trade-off to maintain a uniform trait
-    /// interface across array types without introducing lifetime parameters everywhere.
-    /// For example, numeric types do not require lifetimes, and the alternatives would either be
-    /// 1)  Forcing all non-string types to use `<'a>` across these main trait methods
-    /// 2)  Returning owned string copies rather than borrows.
-    ///  
-    /// Hence, prefer `iter_str` when you have the option, and use this within its actual lifetime
-    /// context when you don't have a choice (i.e., when building off the trait contract).
-    ///
-    /// ## ⚠️ Incorrect Usage (do **not** do this):
-    /// ```no_run
-    /// use minarrow::{MaskedArray, StringArray};
-    /// let data: &str;
-    /// {
-    ///     let arr = StringArray::<u32>::from_slice(&["alpha", "beta"]);
-    ///     data = arr.iter().next().unwrap(); // undefined behaviour
-    /// }
-    /// println!("{}", data); // ⚠️ Bad: Use-after-free - compiler will not complain
-    /// ```
+    /// The yielded `&str` items borrow from `self`. Nulls are not skipped here;
+    /// use `iter_opt` to distinguish null entries.
     #[inline]
-    fn iter(&self) -> impl Iterator<Item = &'static str> + '_ {
+    fn iter(&self) -> impl Iterator<Item = &str> + '_ {
         (0..self.len()).map(move |i| {
             let start = self.offsets[i].to_usize();
             let end = self.offsets[i + 1].to_usize();
-            unsafe {
-                transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                    &self.data[start..end],
-                ))
-            }
+            unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) }
         })
     }
 
-    /// Returns an iterator over `Option<&str>` where null entries return `None`.
-    ///
-    /// # ⚠️ Safety Note
-    ///
-    /// The same caveats apply as in [`iter`]: the returned `String` *must not*
-    /// be assumed to live beyond the array. See `iter` for more explanation.
-    /// ```
+    /// Returns an iterator over `Option<&str>` where null entries yield `None`.
+    /// The yielded references borrow from `self`.
     #[inline]
-    fn iter_opt(&self) -> impl Iterator<Item = Option<&'static str>> + '_ {
+    fn iter_opt(&self) -> impl Iterator<Item = Option<&str>> + '_ {
         (0..self.len()).map(move |i| {
             if self.is_null(i) {
                 None
             } else {
                 let start = self.offsets[i].to_usize();
                 let end = self.offsets[i + 1].to_usize();
-                Some(unsafe {
-                    transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                        &self.data[start..end],
-                    ))
-                })
+                Some(unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) })
             }
         })
     }
 
-    /// Returns an iterator over a range of `&'static str` values for trait compatibility.
-    ///
-    /// ⚠️ WARNING: The returned references are not truly `'static`.
+    /// Returns an iterator over a range of `&str` values borrowed from `self`.
     #[inline]
-    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = &'static str> + '_ {
+    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = &str> + '_ {
         (offset..offset + len).map(move |i| {
             let start = self.offsets[i].to_usize();
             let end = self.offsets[i + 1].to_usize();
-            unsafe {
-                std::mem::transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                    &self.data[start..end],
-                ))
-            }
+            unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) }
         })
     }
 
-    /// Returns an iterator over a range of `Option<&'static str>` values.
-    ///
-    /// ⚠️ WARNING: The returned references are not truly `'static`.
+    /// Returns an iterator over a range of `Option<&str>` values borrowed from `self`.
     #[inline]
     fn iter_opt_range(
         &self,
         offset: usize,
         len: usize,
-    ) -> impl Iterator<Item = Option<&'static str>> + '_ {
+    ) -> impl Iterator<Item = Option<&str>> + '_ {
         (offset..offset + len).map(move |i| {
             if self.is_null(i) {
                 None
             } else {
                 let start = self.offsets[i].to_usize();
                 let end = self.offsets[i + 1].to_usize();
-                Some(unsafe {
-                    std::mem::transmute::<&str, &'static str>(std::str::from_utf8_unchecked(
-                        &self.data[start..end],
-                    ))
-                })
+                Some(unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) })
             }
         })
     }
 
     /// Appends a string value to the array, updating offsets and null mask as required.
     ///
-    /// ⚠️ Prefer `push_str` as it avoids an additional String allocation.
+    /// Prefer `push_str` when you have a `&str` to avoid the `String` allocation.
     #[inline]
     fn push(&mut self, s: String) {
         self.push_str(&s)
@@ -768,10 +639,10 @@ impl<T: Integer> MaskedArray for StringArray<T> {
 
     /// Appends a `String` to the array without any bounds or safety checks.
     ///
-    /// ⚠️ Prefer `push_str` as it avoids an additional String allocation.
+    /// Prefer `push_str_unchecked` when you have a `&str` to avoid the `String` allocation.
     ///
     /// # Safety
-    /// This simply forwards to `push_str_unchecked`, and has the same requirements.
+    /// This forwards to `push_str_unchecked`, and has the same requirements.
     #[inline(always)]
     unsafe fn push_unchecked(&mut self, value: String) {
         unsafe { self.push_str_unchecked(&value) };
@@ -1466,7 +1337,7 @@ impl_arc_masked_array!(
     T = T,
     Container = Buffer<u8>,
     LogicalType = String,
-    CopyType = &'static str,
+    CopyType = &'a str,
     BufferT = u8,
     Variant = TextArray,
     Bound = Integer,

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -143,7 +143,7 @@ impl ArrayV {
 
     /// Returns the value at logical index `i` within the window, or `None` if out of bounds or null.
     #[inline]
-    pub fn get<T: MaskedArray + 'static>(&self, i: usize) -> Option<T::CopyType> {
+    pub fn get<T: MaskedArray + 'static>(&self, i: usize) -> Option<T::CopyType<'_>> {
         if i >= self.len {
             return None;
         }
@@ -151,8 +151,14 @@ impl ArrayV {
     }
 
     /// Returns the value at logical index `i` within the window (unchecked).
+    ///
+    /// # Safety
+    /// `i` must be less than the view's logical length. No bounds check is performed.
     #[inline]
-    pub fn get_unchecked<T: MaskedArray + 'static>(&self, i: usize) -> Option<T::CopyType> {
+    pub unsafe fn get_unchecked<T: MaskedArray + 'static>(
+        &self,
+        i: usize,
+    ) -> Option<T::CopyType<'_>> {
         unsafe { self.array.inner::<T>().get_unchecked(self.offset + i) }
     }
 

--- a/src/traits/masked_array.rs
+++ b/src/traits/masked_array.rs
@@ -47,8 +47,16 @@ pub trait MaskedArray {
     /// The logical type that the data carries
     type LogicalType: Default;
 
-    /// The type that implements `Copy` (e.g., &str)
-    type CopyType: Default;
+    /// The element type returned by `get`/`iter` etc.
+    ///
+    /// Modelled as a generic associated type so that string-like arrays
+    /// can return `&'a str` borrowed from `&self`, instead of widening the
+    /// borrow to `'static` (which would be unsound). For fixed-width types
+    /// like numerics the lifetime is unused and the alias resolves to the
+    /// element type itself, e.g. `type CopyType<'a> = T`.
+    type CopyType<'a>: Default
+    where
+        Self: 'a;
 
     /// **************************************************
     /// The below methods differ for the Boolean (bit-packed),
@@ -73,13 +81,13 @@ pub trait MaskedArray {
     fn data_mut(&mut self) -> &mut Self::Container;
 
     /// Retrieves the value at the given index, or None if null or beyond length.
-    fn get(&self, idx: usize) -> Option<Self::CopyType>;
+    fn get(&self, idx: usize) -> Option<Self::CopyType<'_>>;
 
     /// Sets the value at the given index, updating the null‐mask.
     fn set(&mut self, idx: usize, value: Self::LogicalType);
 
     /// Like `get`, but skips the `idx >= len()` check.
-    unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType>;
+    unsafe fn get_unchecked(&self, idx: usize) -> Option<Self::CopyType<'_>>;
 
     /// Like `set`, but skips bounds checks.
     unsafe fn set_unchecked(&mut self, idx: usize, value: Self::LogicalType);
@@ -98,20 +106,24 @@ pub trait MaskedArray {
     }
 
     /// Returns an iterator over the T values in this array.
-    fn iter(&self) -> impl Iterator<Item = Self::CopyType> + '_;
+    fn iter(&self) -> impl Iterator<Item = Self::CopyType<'_>> + '_;
 
     /// Returns an iterator over the T values, as `Option<Self::T>`.
-    fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType>> + '_;
+    fn iter_opt(&self) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_;
 
     /// Returns an iterator over a range of T values in this array.
-    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = Self::CopyType> + '_;
+    fn iter_range(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> impl Iterator<Item = Self::CopyType<'_>> + '_;
 
     /// Returns an iterator over a range of T values, as `Option<T>`.
     fn iter_opt_range(
         &self,
         offset: usize,
         len: usize,
-    ) -> impl Iterator<Item = Option<Self::CopyType>> + '_;
+    ) -> impl Iterator<Item = Option<Self::CopyType<'_>>> + '_;
 
     /// Appends a value to the array, updating masks if present.
     fn push(&mut self, value: Self::LogicalType);


### PR DESCRIPTION
**Memory audit: Review MaskedArray borrow lifetimes**

- Replace flat `MaskedArray::CopyType` associated type with a
lifetime-parameterised form (`CopyType<'a>` with `Self: 'a`). String and
categorical impls now return `&str` correctly tied to `&self` via the
trait. Numeric, boolean, and datetime impls resolve to the element type as
before; all callsites use lifetime elision.

- Drop the unused `T` parameter from the three Display formatter helpers
(`write_{numeric,temporal,text}_array_with_header`) - the prior
`CopyType = T` bound carried no information they relied on.

- Simplify doc notes on the trait `push` / `set` impls.