### PR TITLE
Fix typed-array null-mask initialisation and push_nulls correctness

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,7 +73,9 @@ macro_rules! impl_numeric_array_constructors {
                 Self {
                     data: Vec64::with_capacity(cap).into(),
                     null_mask: if null_mask {
-                        Some($crate::structs::bitmask::Bitmask::with_capacity(cap))
+                        // All-valid (1) default - new slots represent "no information
+                        // yet" which under Arrow's 1=valid, 0=null convention is valid.
+                        Some($crate::structs::bitmask::Bitmask::new_set_all(cap, true))
                     } else {
                         None
                     },

--- a/src/structs/bitmask.rs
+++ b/src/structs/bitmask.rs
@@ -310,6 +310,51 @@ impl Bitmask {
         self.resize(self.len + n, value);
     }
 
+    /// Set bits in `[start..end)` to `value`.
+    ///
+    /// Bit-precise on the boundary bytes (the byte holding `start` and the
+    /// byte holding `end`); a byte-level fill is used for any whole bytes
+    /// lying fully inside `[start..end)`. The mask auto-grows if
+    /// `end > self.len` via `ensure_capacity`.
+    #[inline]
+    pub fn set_range(&mut self, start: usize, end: usize, value: bool) {
+        if start >= end {
+            return;
+        }
+        self.ensure_capacity(end);
+
+        // Byte boundary at or after `start`, and at or before `end`.
+        let head_end = ((start + 7) / 8) * 8;
+        let tail_start = (end / 8) * 8;
+
+        // Range stays inside the first byte boundary - per-bit only.
+        if head_end >= end {
+            for i in start..end {
+                // SAFETY: i < end <= self.len after ensure_capacity
+                unsafe { self.set_unchecked(i, value) };
+            }
+            return;
+        }
+
+        // Head: bit-precise from `start` up to the next byte boundary.
+        for i in start..head_end {
+            unsafe { self.set_unchecked(i, value) };
+        }
+
+        // Middle: whole bytes fully inside `[start..end)`.
+        let fill = if value { 0xFFu8 } else { 0 };
+        let mid_start_byte = head_end / 8;
+        let mid_end_byte = tail_start / 8;
+        for byte_idx in mid_start_byte..mid_end_byte {
+            self.bits[byte_idx] = fill;
+        }
+
+        // Tail: bit-precise from the last byte boundary up to `end`.
+        for i in tail_start..end {
+            unsafe { self.set_unchecked(i, value) };
+        }
+    }
+
     /// Returns true if all bits are set (all valid).
     #[inline]
     pub fn all_true(&self) -> bool {
@@ -940,6 +985,59 @@ mod tests {
         assert!(m.get(15));
         m.resize(100, false);
         assert!(m.len == 100);
+    }
+
+    #[test]
+    fn test_set_range() {
+        // Single-byte, sub-byte range.
+        let mut m = Bitmask::new_set_all(8, true);
+        m.set_range(1, 4, false);
+        assert!(m.get(0));
+        assert!(!m.get(1));
+        assert!(!m.get(2));
+        assert!(!m.get(3));
+        assert!(m.get(4));
+        assert!(m.get(7));
+
+        // Cross-byte range with head, middle byte, and tail.
+        let mut m = Bitmask::new_set_all(24, false);
+        m.set_range(3, 20, true);
+        for i in 0..3 {
+            assert!(!m.get(i), "leading bit {} should be clear", i);
+        }
+        for i in 3..20 {
+            assert!(m.get(i), "in-range bit {} should be set", i);
+        }
+        for i in 20..24 {
+            assert!(!m.get(i), "trailing bit {} should be clear", i);
+        }
+
+        // Byte-aligned start and end - hits middle byte path with no head/tail loops.
+        let mut m = Bitmask::new_set_all(24, true);
+        m.set_range(8, 16, false);
+        for i in 0..8 {
+            assert!(m.get(i));
+        }
+        for i in 8..16 {
+            assert!(!m.get(i));
+        }
+        for i in 16..24 {
+            assert!(m.get(i));
+        }
+
+        // Empty range is a no-op.
+        let mut m = Bitmask::new_set_all(8, true);
+        m.set_range(3, 3, false);
+        assert!(m.all_set());
+
+        // Auto-grow path: target beyond current len.
+        let mut m = Bitmask::new_set_all(4, true);
+        m.set_range(2, 6, false);
+        assert_eq!(m.len(), 6);
+        assert!(m.get(0));
+        assert!(m.get(1));
+        assert!(!m.get(2));
+        assert!(!m.get(5));
     }
 
     #[test]

--- a/src/structs/bitmask.rs
+++ b/src/structs/bitmask.rs
@@ -466,11 +466,32 @@ impl Bitmask {
     }
 
     /// Resizes mask to new_len. New bits set or cleared per `set`.
+    ///
+    /// Bit-correct across a partial old-byte boundary when extending: the
+    /// byte-level resize only fills *newly added* bytes, so bits in
+    /// `[old_len..next_byte_boundary)` would otherwise be untouched and stay
+    /// at the value the prior `mask_trailing_bits` left them (0). When
+    /// `set` is true those bits are flipped explicitly so the extension
+    /// honours the documented contract regardless of byte alignment.
     pub fn resize(&mut self, new_len: usize, set: bool) {
+        let old_len = self.len;
         let new_bytes = (new_len + 7) / 8;
         let fill = if set { 0xFF } else { 0 };
         self.bits.resize(new_bytes, fill);
         self.len = new_len;
+
+        // Extension across a non-byte-aligned old_len: set=true must reach
+        // the bits in the old partial byte. For set=false the class
+        // invariant already keeps those bits at 0.
+        if set && new_len > old_len && (old_len & 7) != 0 {
+            let byte_boundary = ((old_len + 7) / 8) * 8;
+            let limit = new_len.min(byte_boundary);
+            for i in old_len..limit {
+                // SAFETY: i < limit <= new_len = self.len, byte already exists.
+                unsafe { self.set_unchecked(i, true) };
+            }
+        }
+
         self.mask_trailing_bits();
     }
 
@@ -974,6 +995,33 @@ mod tests {
         assert!(m.get(3));
         m.set(3, false);
         assert!(!m.get(3));
+    }
+
+    #[test]
+    fn test_resize_extend_with_true_across_partial_byte() {
+        // Mask of len 5: bits 0-4 set, bits 5-7 cleared by mask_trailing_bits.
+        let mut m = Bitmask::new_set_all(5, true);
+        assert_eq!(m.len(), 5);
+        for i in 0..5 {
+            assert!(m.get(i), "bit {} should be set before resize", i);
+        }
+
+        // Extending with set=true must set bits 5..8 to 1 even though they
+        // lie inside the old partial byte that the byte-level fill cannot
+        // reach.
+        m.resize(8, true);
+        assert_eq!(m.len(), 8);
+        for i in 0..8 {
+            assert!(m.get(i), "bit {} should be set after resize(8, true)", i);
+        }
+
+        // Extension that crosses a byte boundary: bits 5..12 must all be 1.
+        let mut m = Bitmask::new_set_all(5, true);
+        m.resize(12, true);
+        assert_eq!(m.len(), 12);
+        for i in 0..12 {
+            assert!(m.get(i), "bit {} should be set after resize(12, true)", i);
+        }
     }
 
     #[test]

--- a/src/structs/variants/boolean.rs
+++ b/src/structs/variants/boolean.rs
@@ -1473,4 +1473,60 @@ mod tests_parallel {
         assert!(!null_mask.get(4)); // Last entry is null
         assert_eq!(arr1.null_count(), 1);
     }
+
+    /// Appending a masked `other` onto a masked `self` whose mask len isn't
+    /// byte-aligned must carry `other`'s null mask across element-for-element.
+    /// Covers the `(Some, Some)` branch of `append_array`, which routes
+    /// through `Bitmask::extend_from_bitmask`.
+    #[test]
+    fn test_append_array_masked_other_non_byte_aligned() {
+        use crate::traits::masked_array::MaskedArray;
+
+        // self: 5 elements, all valid - null_mask.len() == 5 (not byte aligned).
+        let mut arr = BooleanArray::from_slice(&[true, false, true, false, true]);
+        arr.null_mask = Some(Bitmask::new_set_all(5, true));
+
+        // other: 3 elements with mask = [valid, null, valid].
+        let mut other = BooleanArray::from_slice(&[true, false, true]);
+        other.null_mask = Some(Bitmask::from_bools(&[true, false, true]));
+
+        arr.append_array(&other);
+
+        assert_eq!(arr.len(), 8);
+        // self's original 5 stay valid; other's mask carries across: v, n, v.
+        for i in 0..5 {
+            assert!(arr.get(i).is_some(), "self position {} must be valid", i);
+        }
+        assert!(arr.get(5).is_some(), "appended position 5 (other[0]) must be valid");
+        assert!(arr.get(6).is_none(), "appended position 6 (other[1]) must be null");
+        assert!(arr.get(7).is_some(), "appended position 7 (other[2]) must be valid");
+        assert_eq!(arr.null_count(), 1);
+    }
+
+    /// Appending an unmasked `other` onto a masked `self` whose mask len
+    /// isn't byte-aligned must mark every appended position valid. Covers
+    /// the `(Some, None)` branch of `append_array`, which routes through
+    /// `Bitmask::resize(_, true)`.
+    #[test]
+    fn test_append_array_unmasked_other_non_byte_aligned() {
+        use crate::traits::masked_array::MaskedArray;
+
+        // self has length 5 with a present-everywhere null mask, so
+        // null_mask.len() == 5 (not a byte boundary).
+        let mut arr = BooleanArray::from_slice(&[true, false, true, false, true]);
+        arr.null_mask = Some(Bitmask::new_set_all(5, true));
+
+        // other has 3 entries and no null mask - every appended position
+        // is implicitly valid.
+        let other = BooleanArray::from_slice(&[false, true, false]);
+        assert!(other.null_mask.is_none());
+
+        arr.append_array(&other);
+
+        assert_eq!(arr.len(), 8);
+        assert_eq!(arr.null_count(), 0);
+        for i in 0..8 {
+            assert!(arr.get(i).is_some(), "position {} must be valid", i);
+        }
+    }
 }

--- a/src/structs/variants/boolean.rs
+++ b/src/structs/variants/boolean.rs
@@ -138,7 +138,9 @@ impl BooleanArray<()> {
         Self {
             data: Bitmask::with_capacity(cap),
             null_mask: if null_mask {
-                Some(Bitmask::with_capacity(cap))
+                // All-valid (1) default - reserved validity slots default to
+                // valid under Arrow's 1=valid, 0=null convention.
+                Some(Bitmask::new_set_all(cap, true))
             } else {
                 None
             },
@@ -540,17 +542,16 @@ impl MaskedArray for BooleanArray<()> {
     #[inline]
     fn push_nulls(&mut self, n: usize) {
         let start = self.len;
-        self.data.resize(start + n, false);
+        let end = start + n;
+        self.data.resize(end, false);
         if let Some(nm) = &mut self.null_mask {
-            nm.resize(start + n, false);
+            nm.set_range(start, end, false);
         } else {
-            let mut nm = Bitmask::new_set_all(start + n, true);
-            for i in start..start + n {
-                nm.set(i, false);
-            }
+            let mut nm = Bitmask::new_set_all(end, true);
+            nm.set_range(start, end, false);
             self.null_mask = Some(nm);
         }
-        self.len += n;
+        self.len = end;
     }
 
     /// Appends a null value to the array without bounds or consistency checks.
@@ -1016,11 +1017,21 @@ mod tests {
         assert!(arr.data.is_empty());
         assert!(arr.null_mask.is_none());
 
-        let arr = BooleanArray::with_capacity(100, true);
+        let mut arr = BooleanArray::with_capacity(100, true);
         assert_eq!(arr.len(), 0);
         assert_eq!(arr.data.capacity(), 100); // logical bits reserved
         assert!(arr.null_mask.is_some());
         assert_eq!(arr.null_mask.as_ref().unwrap().capacity(), 100);
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push(true);
+        arr.push(false);
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]

--- a/src/structs/variants/categorical.rs
+++ b/src/structs/variants/categorical.rs
@@ -161,7 +161,9 @@ impl<T: Integer> CategoricalArray<T> {
             data: Vec64::with_capacity(cap).into(),
             unique_values: unique_values.unwrap_or_default(),
             null_mask: if null_mask {
-                Some(Bitmask::with_capacity(cap))
+                // All-valid (1) default - reserved validity slots default to
+                // valid under Arrow's 1=valid, 0=null convention.
+                Some(Bitmask::new_set_all(cap, true))
             } else {
                 None
             },
@@ -1306,6 +1308,25 @@ mod tests {
         assert!(arr.is_empty());
         assert!(arr.values().is_empty());
     }
+
+    #[test]
+    fn test_new_and_with_capacity() {
+        let mut arr = CategoricalArray::<u32>::with_capacity(8, None, true);
+        assert_eq!(arr.len(), 0);
+        assert!(arr.data.capacity() >= 8);
+        assert!(arr.null_mask.is_some());
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_str("alpha");
+        arr.push_str("beta");
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
+    }
+
     #[test]
     fn push_and_get() {
         let mut arr = CategoricalArray::<u8>::default();

--- a/src/structs/variants/datetime/mod.rs
+++ b/src/structs/variants/datetime/mod.rs
@@ -169,7 +169,9 @@ impl<T: Integer> DatetimeArray<T> {
         Self {
             data: Vec64::with_capacity(cap).into(),
             null_mask: if null_mask {
-                Some(Bitmask::with_capacity(cap))
+                // All-valid (1) default - reserved validity slots default to
+                // valid under Arrow's 1=valid, 0=null convention.
+                Some(Bitmask::new_set_all(cap, true))
             } else {
                 None
             },
@@ -496,11 +498,20 @@ mod tests {
         assert!(arr.data.is_empty());
         assert!(arr.null_mask.is_none());
 
-        let arr = DatetimeArray::<i64>::with_capacity(50, true, None);
+        let mut arr = DatetimeArray::<i64>::with_capacity(50, true, None);
         assert_eq!(arr.len(), 0);
         assert!(arr.data.capacity() >= 50);
         assert!(arr.null_mask.is_some());
-        assert!(arr.null_mask.as_ref().unwrap().capacity() >= 50);
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push(1_700_000_000);
+        arr.push(1_700_000_001);
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]

--- a/src/structs/variants/float.rs
+++ b/src/structs/variants/float.rs
@@ -194,11 +194,22 @@ mod tests {
         assert_eq!(arr.data.len(), 0);
         assert!(arr.null_mask.is_none());
 
-        let arr = FloatArray::<f32>::with_capacity(16, true);
+        let mut arr = FloatArray::<f32>::with_capacity(16, true);
         assert_eq!(arr.data.len(), 0);
         assert!(arr.data.capacity() >= 16);
         assert!(arr.null_mask.is_some());
-        assert!(arr.null_mask.as_ref().unwrap().capacity() >= 2);
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        // After non-null pushes, null_count remains 0 - the pre-allocated
+        // tail bits beyond len() must not poison the count.
+        arr.push(1.5);
+        arr.push(2.5);
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]

--- a/src/structs/variants/integer.rs
+++ b/src/structs/variants/integer.rs
@@ -179,11 +179,24 @@ mod tests {
         assert_eq!(arr.data.len(), 0);
         assert!(arr.null_mask.is_none());
 
-        let arr = IntegerArray::<u16>::with_capacity(8, true);
+        let mut arr = IntegerArray::<u16>::with_capacity(8, true);
         assert_eq!(arr.data.len(), 0);
         assert!(arr.data.capacity() >= 8);
         assert!(arr.null_mask.is_some());
-        assert!(arr.null_mask.as_ref().unwrap().capacity() >= 8);
+
+        // Reserved null-mask slots must default to valid (1).
+        // null_count() == 0 on a fresh, empty array.
+        assert_eq!(arr.null_count(), 0);
+
+        // After non-null pushes, null_count remains 0 - the pre-allocated
+        // tail bits beyond len() must not poison the count.
+        arr.push(10);
+        arr.push(20);
+        assert_eq!(arr.null_count(), 0);
+
+        // A pushed null is the only thing that should bump the count.
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]

--- a/src/structs/variants/string.rs
+++ b/src/structs/variants/string.rs
@@ -159,7 +159,9 @@ impl<T: Integer> StringArray<T> {
             offsets: offsets.into(),
             data: Vec64::with_capacity(values_cap).into(),
             null_mask: if null_mask {
-                Some(Bitmask::with_capacity(n_strings))
+                // All-valid (1) default - reserved validity slots default to
+                // valid under Arrow's 1=valid, 0=null convention.
+                Some(Bitmask::new_set_all(n_strings, true))
             } else {
                 None
             },
@@ -816,12 +818,10 @@ impl<T: Integer> MaskedArray for StringArray<T> {
         self.offsets.resize(end + 1, last);
 
         if let Some(mask) = self.null_mask_mut() {
-            mask.resize(end, false);
+            mask.set_range(start, end, false);
         } else {
             let mut m = Bitmask::new_set_all(end, true);
-            for i in start..end {
-                m.set(i, false);
-            }
+            m.set_range(start, end, false);
             self.set_null_mask(Some(m));
         }
     }
@@ -1478,13 +1478,22 @@ mod tests {
         assert!(arr.data.is_empty());
         assert!(arr.null_mask.is_none());
 
-        let arr: StringArray<u32> = StringArray::with_capacity(10, 64, true);
+        let mut arr: StringArray<u32> = StringArray::with_capacity(10, 64, true);
         assert_eq!(arr.len(), 0);
         assert_eq!(arr.offsets, offsets(&[0]));
         assert!(arr.data.capacity() >= 64);
         assert!(arr.offsets.capacity() >= 11);
         assert!(arr.null_mask.is_some());
-        assert!(arr.null_mask.as_ref().unwrap().capacity() >= 10);
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_str("hello");
+        arr.push_str("world");
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]
@@ -1603,12 +1612,22 @@ mod tests {
         assert!(arr.data.is_empty());
         assert!(arr.null_mask.is_none());
 
-        let arr: StringArray<u64> = StringArray::with_capacity(10, 64, true);
+        let mut arr: StringArray<u64> = StringArray::with_capacity(10, 64, true);
         assert_eq!(arr.len(), 0);
         assert_eq!(arr.offsets, offsets(&[0]));
         assert!(arr.data.capacity() >= 64);
         assert!(arr.offsets.capacity() >= 11);
         assert!(arr.null_mask.is_some());
+
+        // Reserved null-mask slots must default to valid (1).
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_str("hello");
+        arr.push_str("world");
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
     }
 
     #[test]

--- a/src/traits/masked_array.rs
+++ b/src/traits/masked_array.rs
@@ -268,12 +268,10 @@ pub trait MaskedArray {
         self.resize(end, Self::LogicalType::default());
 
         if let Some(mask) = self.null_mask_mut() {
-            mask.resize(end, false);
+            mask.set_range(start, end, false);
         } else {
             let mut m = Bitmask::new_set_all(end, true);
-            for i in start..end {
-                m.set(i, false);
-            }
+            m.set_range(start, end, false);
             self.set_null_mask(Some(m));
         }
     }


### PR DESCRIPTION
Typed-array `with_capacity(N, true)` was building the null mask via `Bitmask::with_capacity(N)`, which leaves every reserved bit cleared. Under Arrow's `1 = valid, 0 = null` convention this meant a freshly reserved array reported `null_count() == N` for an empty array.

Switch the five typed-array constructors to `Bitmask::new_set_all(cap, true)` so reserved validity slots default to valid. `Bitmask` itself is unchanged - cleared bits remain the right default for a generic bit container, and the null-mask convention is owned by the typed arrays.

`push_nulls` was relying on the prior all-zero default: it called `mask.resize(end, false)`, which under the pre-sized mask is a shrink that preserves bits in `[0..new_len)` and so left the new positions marked valid instead of null. Add `Bitmask::set_range(start, end, value)` - bit-precise on the boundary bytes, byte fill for whole middle bytes, auto-grows via `ensure_capacity` - and have the three `push_nulls` impls call it.

Tests added: `Bitmask::test_set_range` covers sub-byte, cross-byte, byte-aligned, empty and auto-grow paths. Each typed array's `test_new_and_with_capacity` now asserts `null_count() == 0` on a fresh `with_capacity(N, true)`, plus stability across non-null pushes and a single `push_null`. `CategoricalArray` gains the test it was missing.