### PR TITLE
Extend macros

### DIFF
--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -3311,10 +3311,29 @@ macro_rules! has_nulls {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! arr_i8 {
-    // Handle Vec64 input
-    ($v:expr) => {
-        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64($v, None))
+    // Literal array ref `&[a, b, c]` + Bitmask
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64(temp_vec, Some($mask)))
+    }};
+    // Literal array ref `&[a, b, c]`
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64(temp_vec, None))
+    }};
+    // Values + Bitmask, semicolon-separated
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64($v.into(), Some($mask)))
     };
+    // Handle Vec64 or `&[i8]` input via `Into<Vec64<i8>>`
+    ($v:expr) => {
+        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64($v.into(), None))
+    };
+    // Literal elements + Bitmask
+    ($($x:expr),+ ; $mask:expr) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int8($crate::IntegerArray::<i8>::from_vec64(temp_vec, Some($mask)))
+    }};
     // Handle literal arrays
     ($($x:expr),+ $(,)?) => {{
         // Check if any element is None by trying to match patterns
@@ -3330,9 +3349,24 @@ macro_rules! arr_i8 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! arr_i16 {
-    ($v:expr) => {
-        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int16($crate::IntegerArray::<i16>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         let temp_vec = vec64![$($x),+];
@@ -3345,9 +3379,27 @@ macro_rules! arr_i16 {
 
 #[macro_export]
 macro_rules! arr_i32 {
-    ($v:expr) => {
-        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int32($crate::IntegerArray::<i32>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3361,9 +3413,27 @@ macro_rules! arr_i32 {
 
 #[macro_export]
 macro_rules! arr_i64 {
-    ($v:expr) => {
-        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_int64($crate::IntegerArray::<i64>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3446,9 +3516,27 @@ macro_rules! arr_dt64 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! arr_u8 {
-    ($v:expr) => {
-        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint8($crate::IntegerArray::<u8>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3463,9 +3551,27 @@ macro_rules! arr_u8 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! arr_u16 {
-    ($v:expr) => {
-        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint16($crate::IntegerArray::<u16>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3479,9 +3585,27 @@ macro_rules! arr_u16 {
 
 #[macro_export]
 macro_rules! arr_u32 {
-    ($v:expr) => {
-        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint32($crate::IntegerArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3495,9 +3619,27 @@ macro_rules! arr_u32 {
 
 #[macro_export]
 macro_rules! arr_u64 {
-    ($v:expr) => {
-        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_uint64($crate::IntegerArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3513,9 +3655,27 @@ macro_rules! arr_u64 {
 
 #[macro_export]
 macro_rules! arr_f32 {
-    ($v:expr) => {
-        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float32($crate::FloatArray::<f32>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3529,9 +3689,27 @@ macro_rules! arr_f32 {
 
 #[macro_export]
 macro_rules! arr_f64 {
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64($v.into(), Some($mask)))
+    };
     ($v:expr) => {
-            $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64($v, None))
+            $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64($v.into(), None))
         };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_float64($crate::FloatArray::<f64>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
         use $crate::vec64;
         let temp_vec = vec64![$($x),+];
@@ -3546,9 +3724,27 @@ macro_rules! arr_f64 {
 
 #[macro_export]
 macro_rules! arr_bool {
-    ($v:expr) => {
-        $crate::Array::from_bool($crate::BooleanArray::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_bool($crate::BooleanArray::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_bool($crate::BooleanArray::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_bool($crate::BooleanArray::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_bool($crate::BooleanArray::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_bool($crate::BooleanArray::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3564,9 +3760,27 @@ macro_rules! arr_bool {
 
 #[macro_export]
 macro_rules! arr_str32 {
-    ($v:expr) => {
-        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string32($crate::StringArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3581,9 +3795,27 @@ macro_rules! arr_str32 {
 #[cfg(feature = "large_string")]
 #[macro_export]
 macro_rules! arr_str64 {
-    ($v:expr) => {
-        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_string64($crate::StringArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3600,9 +3832,27 @@ macro_rules! arr_str64 {
 #[cfg(feature = "default_categorical_8")]
 #[macro_export]
 macro_rules! arr_cat8 {
-    ($v:expr) => {
-        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical8($crate::CategoricalArray::<u8>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3617,9 +3867,27 @@ macro_rules! arr_cat8 {
 #[cfg(feature = "extended_categorical")]
 #[macro_export]
 macro_rules! arr_cat16 {
-    ($v:expr) => {
-        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical16($crate::CategoricalArray::<u16>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3634,9 +3902,27 @@ macro_rules! arr_cat16 {
 #[cfg(any(not(feature = "default_categorical_8"), feature = "extended_categorical"))]
 #[macro_export]
 macro_rules! arr_cat32 {
-    ($v:expr) => {
-        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical32($crate::CategoricalArray::<u32>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -3651,9 +3937,27 @@ macro_rules! arr_cat32 {
 #[cfg(feature = "extended_categorical")]
 #[macro_export]
 macro_rules! arr_cat64 {
-    ($v:expr) => {
-        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64($v, None))
+    (&[ $($x:expr),+ $(,)? ] ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
+    (&[ $($x:expr),+ $(,)? ]) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64(temp_vec, None))
+    }};
+    ($v:expr; $mask:expr) => {
+        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64($v.into(), Some($mask)))
     };
+    ($v:expr) => {
+        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64($v.into(), None))
+    };
+    ($($x:expr),+ ; $mask:expr) => {{
+        use $crate::vec64;
+        let temp_vec = vec64![$($x),+];
+        $crate::Array::from_categorical64($crate::CategoricalArray::<u64>::from_vec64(temp_vec, Some($mask)))
+    }};
     ($($x:expr),+ $(,)?) => {{
 
         use $crate::vec64;
@@ -5423,5 +5727,156 @@ mod concat_tests {
         let result = arr1.concat(arr2).unwrap();
 
         assert!(matches!(result, Array::Null));
+    }
+}
+
+#[cfg(test)]
+mod arr_macro_extensions_tests {
+    use crate::{Array, Bitmask, NumericArray, TextArray, Vec64, vec64};
+
+    fn expect_int32_mask(arr: Array) -> (Vec<i32>, Option<Bitmask>) {
+        match arr {
+            Array::NumericArray(NumericArray::Int32(a)) => {
+                (a.data.as_slice().to_vec(), a.null_mask.clone())
+            }
+            _ => panic!("expected Int32 Array"),
+        }
+    }
+
+    fn expect_f64_mask(arr: Array) -> (Vec<f64>, Option<Bitmask>) {
+        match arr {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                (a.data.as_slice().to_vec(), a.null_mask.clone())
+            }
+            _ => panic!("expected Float64 Array"),
+        }
+    }
+
+    fn expect_bool_mask(arr: Array) -> (Vec<bool>, Option<Bitmask>) {
+        match arr {
+            Array::BooleanArray(a) => {
+                let data = (0..a.data.len()).map(|i| a.data.get(i)).collect();
+                (data, a.null_mask.clone())
+            }
+            _ => panic!("expected Boolean Array"),
+        }
+    }
+
+    #[test]
+    fn arr_f64_accepts_slice_dense() {
+        let s: &[f64] = &[1.0, 2.0, 3.0];
+        let (data, mask) = expect_f64_mask(arr_f64!(s));
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert!(mask.is_none());
+    }
+
+    #[test]
+    fn arr_f64_accepts_vec64_dense() {
+        let v: Vec64<f64> = vec64![1.0, 2.0, 3.0];
+        let (data, mask) = expect_f64_mask(arr_f64!(v));
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert!(mask.is_none());
+    }
+
+    #[test]
+    fn arr_f64_literal_elements_unchanged() {
+        let (data, mask) = expect_f64_mask(arr_f64![1.0, 2.0, 3.0]);
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert!(mask.is_none());
+    }
+
+    #[test]
+    fn arr_f64_accepts_literal_array_ref() {
+        let (data, mask) = expect_f64_mask(arr_f64!(&[1.0, 2.0, 3.0]));
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert!(mask.is_none());
+    }
+
+    #[test]
+    fn arr_f64_slice_with_mask() {
+        let s: &[f64] = &[1.0, 2.0, 3.0];
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let (data, mask) = expect_f64_mask(arr_f64!(s; m));
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        let m = mask.expect("expected mask");
+        assert_eq!(m.get(0), true);
+        assert_eq!(m.get(1), false);
+        assert_eq!(m.get(2), true);
+    }
+
+    #[test]
+    fn arr_f64_vec64_with_mask() {
+        let v: Vec64<f64> = vec64![10.0, 20.0, 30.0];
+        let m = Bitmask::from_bools(&[true, true, false]);
+        let (data, mask) = expect_f64_mask(arr_f64!(v; m));
+        assert_eq!(data, vec![10.0, 20.0, 30.0]);
+        let m = mask.expect("expected mask");
+        assert_eq!(m.get(2), false);
+    }
+
+    #[test]
+    fn arr_f64_literal_elements_with_mask() {
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let (data, mask) = expect_f64_mask(arr_f64!(1.0, 2.0, 3.0 ; m));
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(mask.expect("expected mask").get(1), false);
+    }
+
+    #[test]
+    fn arr_f64_literal_array_ref_with_mask() {
+        let m = Bitmask::from_bools(&[true, false]);
+        let (data, mask) = expect_f64_mask(arr_f64!(&[1.0, 2.0]; m));
+        assert_eq!(data, vec![1.0, 2.0]);
+        assert_eq!(mask.expect("expected mask").get(1), false);
+    }
+
+    #[test]
+    fn arr_i32_slice_and_mask() {
+        let s: &[i32] = &[10, 20, 30];
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let (data, mask) = expect_int32_mask(arr_i32!(s; m));
+        assert_eq!(data, vec![10, 20, 30]);
+        assert_eq!(mask.expect("expected mask").get(1), false);
+    }
+
+    #[test]
+    fn arr_bool_slice_and_mask() {
+        let s: &[bool] = &[true, false, true];
+        let m = Bitmask::from_bools(&[true, true, false]);
+        let (data, mask) = expect_bool_mask(arr_bool!(s; m));
+        assert_eq!(data, vec![true, false, true]);
+        assert_eq!(mask.expect("expected mask").get(2), false);
+    }
+
+    #[test]
+    fn arr_str32_slice_and_mask() {
+        let s: &[&str] = &["alpha", "beta", "gamma"];
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let arr = arr_str32!(s; m);
+        match arr {
+            Array::TextArray(TextArray::String32(a)) => {
+                assert_eq!(a.get_str(0), Some("alpha"));
+                assert_eq!(a.get_str(2), Some("gamma"));
+                let mask = a.null_mask.as_ref().expect("expected mask");
+                assert_eq!(mask.get(1), false);
+            }
+            _ => panic!("expected String32 Array"),
+        }
+    }
+
+    #[cfg(any(feature = "default_categorical_8", not(feature = "default_categorical_8")))]
+    #[test]
+    fn arr_cat32_slice_and_mask() {
+        let s: &[&str] = &["red", "green", "red"];
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let arr = arr_cat32!(s; m);
+        match arr {
+            Array::TextArray(TextArray::Categorical32(a)) => {
+                assert_eq!(a.get_str(0), Some("red"));
+                let mask = a.null_mask.as_ref().expect("expected mask");
+                assert_eq!(mask.get(1), false);
+            }
+            _ => panic!("expected Categorical32 Array"),
+        }
     }
 }

--- a/src/structs/chunked/super_table.rs
+++ b/src/structs/chunked/super_table.rs
@@ -1202,6 +1202,52 @@ impl From<SuperTableV> for SuperTable {
     }
 }
 
+/// Ergonomic constructor for a [`SuperTable`] from named table batches.
+///
+/// Each batch argument may be a `Table` or `Arc<Table>`; both flow
+/// through `.into()` into the required `Arc<Table>`. When the first
+/// argument is a string literal it becomes the SuperTable name;
+/// otherwise the first batch's name is used.
+///
+/// # Forms
+/// - `st!("name", batch1, batch2, ...)` - named SuperTable from batches.
+/// - `st!(batch1, batch2, ...)` - name derived from the first batch.
+/// - `st!("name")` - empty SuperTable with the supplied name.
+///
+/// # Example
+/// ```
+/// use minarrow::{fa_i32, st, tbl};
+///
+/// let a = tbl!("batch", fa_i32!("x", 1, 2));
+/// let b = tbl!("batch", fa_i32!("x", 3, 4));
+/// let s = st!("rolling", a, b);
+/// assert_eq!(s.name, "rolling");
+/// assert_eq!(s.n_rows, 4);
+/// ```
+///
+/// # Note
+/// The named form requires a string literal for the name. For a
+/// dynamic `String` name use `SuperTable::from_batches(..., Some(name))`
+/// directly.
+#[macro_export]
+macro_rules! st {
+    ($name:literal, $($t:expr),+ $(,)?) => {
+        $crate::SuperTable::from_batches(
+            ::std::vec::Vec::from([$(::std::convert::Into::<::std::sync::Arc<$crate::Table>>::into($t)),+]),
+            ::std::option::Option::Some(::std::string::String::from($name)),
+        )
+    };
+    ($name:literal) => {
+        $crate::SuperTable::new(::std::string::String::from($name))
+    };
+    ($($t:expr),+ $(,)?) => {
+        $crate::SuperTable::from_batches(
+            ::std::vec::Vec::from([$(::std::convert::Into::<::std::sync::Arc<$crate::Table>>::into($t)),+]),
+            ::std::option::Option::None,
+        )
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2011,5 +2057,69 @@ mod tests {
             }
             _ => panic!("Expected Datetime64"),
         }
+    }
+}
+
+#[cfg(test)]
+mod st_macro_tests {
+    use std::sync::Arc;
+
+    use crate::{fa_i32, tbl, SuperTable, Table};
+
+    fn make_batch(name: &str, ids: &[i32]) -> Table {
+        tbl!("batch", fa_i32!(name, @slice ids))
+    }
+
+    #[test]
+    fn st_named_from_tables() {
+        let a = make_batch("x", &[1, 2]);
+        let b = make_batch("x", &[3, 4, 5]);
+        let st: SuperTable = st!("rolling", a, b);
+        assert_eq!(st.name, "rolling");
+        assert_eq!(st.batches.len(), 2);
+        assert_eq!(st.n_rows, 5);
+    }
+
+    #[test]
+    fn st_auto_name_uses_first_batch_name() {
+        let a = make_batch("x", &[1, 2]);
+        let b = make_batch("x", &[3]);
+        let st: SuperTable = st!(a, b);
+        assert_eq!(st.name, "batch");
+        assert_eq!(st.batches.len(), 2);
+        assert_eq!(st.n_rows, 3);
+    }
+
+    #[test]
+    fn st_accepts_arc_table() {
+        let a: Arc<Table> = Arc::new(make_batch("x", &[1, 2]));
+        let b: Arc<Table> = Arc::new(make_batch("x", &[3, 4]));
+        let st: SuperTable = st!("arc", a, b);
+        assert_eq!(st.name, "arc");
+        assert_eq!(st.n_rows, 4);
+    }
+
+    #[test]
+    fn st_name_only_builds_empty_supertable() {
+        let st: SuperTable = st!("scratch");
+        assert_eq!(st.name, "scratch");
+        assert_eq!(st.batches.len(), 0);
+        assert_eq!(st.n_rows, 0);
+    }
+
+    #[test]
+    fn st_single_batch_named() {
+        let a = make_batch("x", &[7, 8, 9]);
+        let st: SuperTable = st!("solo", a);
+        assert_eq!(st.batches.len(), 1);
+        assert_eq!(st.n_rows, 3);
+    }
+
+    #[test]
+    fn st_trailing_comma_accepted() {
+        let a = make_batch("x", &[1]);
+        let b = make_batch("x", &[2]);
+        let st: SuperTable = st!("trail", a, b,);
+        assert_eq!(st.batches.len(), 2);
     }
 }

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -722,10 +722,25 @@ impl RowSelection for FieldArray {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! fa_i8 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i8!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i8!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i8!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i8!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i8!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i8!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i8!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -741,10 +756,25 @@ macro_rules! fa_i8 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! fa_i16 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i16!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i16!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i16!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i16!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i16!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i16!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i16!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -759,10 +789,25 @@ macro_rules! fa_i16 {
 
 #[macro_export]
 macro_rules! fa_i32 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i32!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i32!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i32!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i32!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i32!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i32!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i32!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -777,10 +822,25 @@ macro_rules! fa_i32 {
 
 #[macro_export]
 macro_rules! fa_i64 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i64!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i64!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i64!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i64!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i64!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_i64!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_i64!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -796,10 +856,25 @@ macro_rules! fa_i64 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! fa_u8 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u8!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u8!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u8!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u8!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u8!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u8!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u8!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -815,10 +890,25 @@ macro_rules! fa_u8 {
 #[cfg(feature = "extended_numeric_types")]
 #[macro_export]
 macro_rules! fa_u16 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u16!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u16!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u16!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u16!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u16!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u16!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u16!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -833,10 +923,25 @@ macro_rules! fa_u16 {
 
 #[macro_export]
 macro_rules! fa_u32 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u32!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u32!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u32!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u32!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u32!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u32!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u32!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -851,10 +956,25 @@ macro_rules! fa_u32 {
 
 #[macro_export]
 macro_rules! fa_u64 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u64!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u64!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u64!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u64!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u64!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_u64!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_u64!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -871,10 +991,25 @@ macro_rules! fa_u64 {
 
 #[macro_export]
 macro_rules! fa_f32 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f32!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f32!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f32!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f32!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_f32!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f32!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_f32!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -889,10 +1024,25 @@ macro_rules! fa_f32 {
 
 #[macro_export]
 macro_rules! fa_f64 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f64!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f64!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f64!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f64!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_f64!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_f64!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_f64!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -909,10 +1059,25 @@ macro_rules! fa_f64 {
 
 #[macro_export]
 macro_rules! fa_bool {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_bool!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_bool!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_bool!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_bool!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_bool!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_bool!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_bool!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -929,10 +1094,25 @@ macro_rules! fa_bool {
 
 #[macro_export]
 macro_rules! fa_str32 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str32!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str32!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str32!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str32!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_str32!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str32!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_str32!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -948,10 +1128,25 @@ macro_rules! fa_str32 {
 #[cfg(feature = "large_string")]
 #[macro_export]
 macro_rules! fa_str64 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str64!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str64!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str64!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str64!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_str64!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_str64!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_str64!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -969,10 +1164,25 @@ macro_rules! fa_str64 {
 #[cfg(feature = "default_categorical_8")]
 #[macro_export]
 macro_rules! fa_cat8 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat8!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat8!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat8!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat8!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat8!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat8!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat8!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -988,10 +1198,25 @@ macro_rules! fa_cat8 {
 #[cfg(feature = "extended_categorical")]
 #[macro_export]
 macro_rules! fa_cat16 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat16!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat16!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat16!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat16!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat16!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat16!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat16!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -1007,10 +1232,25 @@ macro_rules! fa_cat16 {
 #[cfg(any(not(feature = "default_categorical_8"), feature = "extended_categorical"))]
 #[macro_export]
 macro_rules! fa_cat32 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat32!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat32!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat32!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat32!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat32!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat32!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat32!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -1026,10 +1266,25 @@ macro_rules! fa_cat32 {
 #[cfg(feature = "extended_categorical")]
 #[macro_export]
 macro_rules! fa_cat64 {
+    ($name:expr, @vec64 $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat64!($v; $mask))
+    };
+    ($name:expr, @slice $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat64!($v; $mask))
+    };
+    ($name:expr, $v:expr; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat64!($v; $mask))
+    };
+    ($name:expr, $first:expr, $($rest:expr),+ ; $mask:expr) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat64!($first, $($rest),+ ; $mask))
+    };
     ($name:expr, $first:expr, $($rest:expr),+ $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat64!($first, $($rest),+))
     };
     ($name:expr, @vec64 $v:expr $(,)?) => {
+        $crate::FieldArray::from_arr($name, $crate::arr_cat64!($v))
+    };
+    ($name:expr, @slice $v:expr $(,)?) => {
         $crate::FieldArray::from_arr($name, $crate::arr_cat64!($v))
     };
     ($name:expr, $v:expr $(,)?) => {{
@@ -1783,5 +2038,84 @@ mod fa_macro_tests {
         let fa = fa_i32!("data", 5, 6, 7,);
         assert_eq!(fa.field.name, "data");
         assert_eq!(fa.len(), 3);
+    }
+}
+
+#[cfg(test)]
+mod fa_macro_extensions_tests {
+    use crate::{Array, Bitmask, NumericArray, Vec64, vec64};
+
+    fn f64_values_and_mask(fa: &crate::FieldArray) -> (Vec<f64>, Option<Bitmask>) {
+        match &fa.array {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                (a.data.as_slice().to_vec(), a.null_mask.clone())
+            }
+            _ => panic!("expected Float64 FieldArray"),
+        }
+    }
+
+    #[test]
+    fn fa_f64_vec64_marker_with_mask() {
+        let v: Vec64<f64> = vec64![1.0, 2.0, 3.0];
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let fa = fa_f64!("a", @vec64 v; m);
+        assert_eq!(fa.field.name, "a");
+        let (data, mask) = f64_values_and_mask(&fa);
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(mask.expect("expected mask").get(1), false);
+    }
+
+    #[test]
+    fn fa_f64_slice_marker_with_mask() {
+        let s: &[f64] = &[1.0, 2.0, 3.0];
+        let m = Bitmask::from_bools(&[false, true, true]);
+        let fa = fa_f64!("a", @slice s; m);
+        let (data, mask) = f64_values_and_mask(&fa);
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(mask.expect("expected mask").get(0), false);
+    }
+
+    #[test]
+    fn fa_f64_bare_values_with_mask() {
+        let s: &[f64] = &[10.0, 20.0, 30.0];
+        let m = Bitmask::from_bools(&[true, true, false]);
+        let fa = fa_f64!("a", s; m);
+        let (data, mask) = f64_values_and_mask(&fa);
+        assert_eq!(data, vec![10.0, 20.0, 30.0]);
+        assert_eq!(mask.expect("expected mask").get(2), false);
+    }
+
+    #[test]
+    fn fa_f64_literal_multi_with_mask() {
+        let m = Bitmask::from_bools(&[true, false, true]);
+        let fa = fa_f64!("a", 1.0, 2.0, 3.0 ; m);
+        let (data, mask) = f64_values_and_mask(&fa);
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+        assert_eq!(mask.expect("expected mask").get(1), false);
+    }
+
+    #[test]
+    fn fa_f64_slice_marker_no_mask() {
+        let s: &[f64] = &[1.0, 2.0];
+        let fa = fa_f64!("a", @slice s);
+        let (data, mask) = f64_values_and_mask(&fa);
+        assert_eq!(data, vec![1.0, 2.0]);
+        assert!(mask.is_none());
+    }
+
+    #[test]
+    fn fa_f64_existing_forms_unchanged() {
+        let single = fa_f64!("a", 42.0);
+        assert_eq!(single.len(), 1);
+
+        let multi = fa_f64!("a", 1.0, 2.0, 3.0);
+        assert_eq!(multi.len(), 3);
+
+        let v: Vec64<f64> = vec64![5.0, 6.0];
+        let from_vec = fa_f64!("a", @vec64 v);
+        assert_eq!(from_vec.len(), 2);
+
+        let empty = fa_f64!("a");
+        assert_eq!(empty.len(), 0);
     }
 }

--- a/src/structs/matrix.rs
+++ b/src/structs/matrix.rs
@@ -872,6 +872,51 @@ impl IntoIterator for Matrix {
     }
 }
 
+/// Ergonomic constructor for a [`Matrix`] from `f64` column data.
+///
+/// Both forms build through [`Matrix::try_from_cols`] and unwrap the
+/// result, so a length mismatch panics with the same error shape as the
+/// underlying call.
+///
+/// # Forms
+/// - Literal columns: `mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]` produces
+///   a 3-row, 2-column matrix.
+/// - Slice-of-slices expression: `mat!(&[&[1.0, 2.0, 3.0][..], &[4.0, 5.0, 6.0][..]])`
+///   produces the equivalent matrix from an existing `&[&[f64]]` value.
+///
+/// # Example
+/// ```
+/// use minarrow::mat;
+/// let m = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+/// assert_eq!((m.n_rows, m.n_cols), (3, 2));
+/// ```
+#[cfg(feature = "matrix")]
+#[macro_export]
+macro_rules! mat {
+    // Literal column form: one or more bracketed column literals.
+    ($([ $($x:expr),+ $(,)? ]),+ $(,)?) => {{
+        $crate::Matrix::try_from_cols(
+            &[
+                $( $crate::FloatArray::<f64>::from_slice(&[$($x),+]) ),+
+            ][..],
+            None,
+        ).unwrap()
+    }};
+
+    // Slice-of-slices form: a single expression evaluating to `&[&[f64]]`.
+    ($cols:expr $(,)?) => {{
+        let cols_ref: &[&[f64]] = $cols;
+        $crate::Matrix::try_from_cols(
+            cols_ref
+                .iter()
+                .map(|c| $crate::FloatArray::<f64>::from_slice(*c))
+                .collect::<::std::vec::Vec<_>>()
+                .as_slice(),
+            None,
+        ).unwrap()
+    }};
+}
+
 #[cfg(all(test, feature = "views"))]
 mod try_as_matrix_zc_tests {
     use super::*;
@@ -1071,5 +1116,43 @@ mod try_as_matrix_zc_tests {
         let view = TableV::from_table(table, 0, 3);
         let err = view.try_as_matrix().expect_err("non-f64 column must reject");
         assert!(matches!(err, MinarrowError::TypeError { .. }));
+    }
+}
+
+#[cfg(test)]
+mod mat_macro_tests {
+    #[test]
+    fn literal_columns_form_builds_3x2() {
+        let m = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        assert_eq!(m.n_rows, 3);
+        assert_eq!(m.n_cols, 2);
+        assert_eq!(m.col(0), &[1.0, 2.0, 3.0]);
+        assert_eq!(m.col(1), &[4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn slice_of_slices_form_builds_equivalent_matrix() {
+        let cols: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]];
+        let m = mat!(cols);
+        let expected = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+
+        assert_eq!(m.n_rows, expected.n_rows);
+        assert_eq!(m.n_cols, expected.n_cols);
+        for c in 0..m.n_cols {
+            assert_eq!(m.col(c), expected.col(c));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "ColumnLengthMismatch")]
+    fn literal_columns_length_mismatch_panics() {
+        let _ = mat![[1.0, 2.0, 3.0], [4.0, 5.0]];
+    }
+
+    #[test]
+    #[should_panic(expected = "ColumnLengthMismatch")]
+    fn slice_of_slices_length_mismatch_panics() {
+        let cols: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0]];
+        let _ = mat!(cols);
     }
 }

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -1211,6 +1211,37 @@ impl RowSelection for Table {
     }
 }
 
+/// Ergonomic constructor for a [`Table`] from named columns.
+///
+/// The first argument is the table name. Subsequent arguments are
+/// `FieldArray` columns, comma-separated. An empty table is built when
+/// only a name is provided.
+///
+/// # Example
+/// ```
+/// use minarrow::{fa_f64, fa_i32, tbl};
+///
+/// let t = tbl!("orders",
+///     fa_i32!("id", 1, 2, 3),
+///     fa_f64!("qty", 10.0, 20.0, 30.0),
+/// );
+/// assert_eq!(t.name, "orders");
+/// assert_eq!(t.cols.len(), 2);
+/// assert_eq!(t.n_rows, 3);
+/// ```
+#[macro_export]
+macro_rules! tbl {
+    ($name:expr, $($col:expr),+ $(,)?) => {
+        $crate::Table::new(
+            ::std::string::String::from($name),
+            ::std::option::Option::Some(::std::vec::Vec::from([$($col),+])),
+        )
+    };
+    ($name:expr) => {
+        $crate::Table::new(::std::string::String::from($name), ::std::option::Option::None)
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1863,5 +1894,55 @@ mod parallel_column_tests {
         let mut names: Vec<&str> = table.par_iter().map(|fa| fa.field.name.as_str()).collect();
         names.sort_unstable(); // Ensure deterministic order for assert
         assert_eq!(names, vec!["flag", "id"]);
+    }
+}
+
+#[cfg(test)]
+mod tbl_macro_tests {
+    use crate::{fa_f64, fa_i32};
+
+    #[test]
+    fn tbl_builds_two_column_table() {
+        let t = tbl!("orders",
+            fa_i32!("id", 1, 2, 3),
+            fa_f64!("qty", 10.0, 20.0, 30.0),
+        );
+        assert_eq!(t.name, "orders");
+        assert_eq!(t.cols.len(), 2);
+        assert_eq!(t.n_rows, 3);
+        assert_eq!(t.cols[0].field.name, "id");
+        assert_eq!(t.cols[1].field.name, "qty");
+    }
+
+    #[test]
+    fn tbl_accepts_string_name() {
+        let name: String = "owned".into();
+        let t = tbl!(name, fa_i32!("x", 1, 2));
+        assert_eq!(t.name, "owned");
+        assert_eq!(t.cols.len(), 1);
+    }
+
+    #[test]
+    fn tbl_name_only_builds_empty_table() {
+        let t = tbl!("scratch");
+        assert_eq!(t.name, "scratch");
+        assert_eq!(t.cols.len(), 0);
+        assert_eq!(t.n_rows, 0);
+    }
+
+    #[test]
+    fn tbl_trailing_comma_accepted() {
+        let t = tbl!("orders",
+            fa_i32!("id", 1, 2),
+            fa_f64!("qty", 5.0, 6.0),
+        );
+        assert_eq!(t.cols.len(), 2);
+    }
+
+    #[test]
+    fn tbl_single_column() {
+        let t = tbl!("single", fa_i32!("x", 1, 2, 3));
+        assert_eq!(t.cols.len(), 1);
+        assert_eq!(t.n_rows, 3);
     }
 }


### PR DESCRIPTION
Adds ergonomic macros for:

1. Extend `Arrays` and `FieldArray` macros to include null mask support.
2. Add `Table` construction support via`tbl!` macro.
3. Add `SuperTable` construction support via `st!` macro.
4. Add `Matrix` construction support via `mat!` macro.